### PR TITLE
Use spawn for agent send to remove timeout ceiling

### DIFF
--- a/src/services/maestro.ts
+++ b/src/services/maestro.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
@@ -82,7 +82,6 @@ type RunOptions = {
 };
 
 const DEFAULT_TIMEOUT_MS = 30 * 1000;
-const SEND_TIMEOUT_MS = 5 * 60 * 1000; // 5 min — agent responses can take a while
 const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024; // 10MB
 
 async function run(args: string[], opts: RunOptions = {}): Promise<string> {
@@ -104,6 +103,44 @@ async function run(args: string[], opts: RunOptions = {}): Promise<string> {
     console.error(`[maestro-cli ${args[0]}] ${detail}`);
     throw new Error(`maestro-cli ${args[0]} failed: ${detail}`);
   }
+}
+
+/**
+ * Spawn maestro-cli without a timeout. Used for agent send operations where
+ * response times are unpredictable (research tasks, complex code generation).
+ * Collects stdout/stderr and resolves when the process exits.
+ */
+function runSpawn(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('maestro-cli', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const chunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    child.stdout.on('data', (data: Buffer) => chunks.push(data));
+    child.stderr.on('data', (data: Buffer) => stderrChunks.push(data));
+
+    child.on('error', (err) => {
+      console.error(`[maestro-cli ${args[0]}] spawn error: ${err.message}`);
+      reject(new Error(`maestro-cli ${args[0]} failed: spawn error: ${err.message}`));
+    });
+
+    child.on('close', (code) => {
+      const stdout = Buffer.concat(chunks).toString().trim();
+      const stderr = Buffer.concat(stderrChunks).toString().trim();
+
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        const parts: string[] = [];
+        if (code !== null) parts.push(`exit code: ${code}`);
+        if (stderr) parts.push(`stderr: ${stderr}`);
+        if (stdout) parts.push(`stdout: ${stdout}`);
+        const detail = parts.join(' | ');
+        console.error(`[maestro-cli ${args[0]}] ${detail}`);
+        reject(new Error(`maestro-cli ${args[0]} failed: ${detail}`));
+      }
+    });
+  });
 }
 
 // --- Service ---
@@ -141,7 +178,7 @@ export const maestro = {
     if (sessionId) args.push('-s', sessionId);
     if (readOnly) args.push('-r');
     try {
-      const raw = await run(args, { timeoutMs: SEND_TIMEOUT_MS });
+      const raw = await runSpawn(args);
       return JSON.parse(raw) as SendResult;
     } catch (err: unknown) {
       // CLI may exit non-zero but still return valid JSON (e.g. read-only rejection)


### PR DESCRIPTION
## Summary

- Replaces `execFile` (5-minute timeout) with `spawn` (no timeout) for `maestro.send()` operations
- Agent responses for long-running tasks (research, complex code generation) no longer fail with a timeout error
- All other CLI operations (`list`, `status`, etc.) retain the existing 30-second timeout via `run()`

## Context

When agents perform multi-step research or complex tasks, responses can exceed the 5-minute `SEND_TIMEOUT_MS` ceiling. The bot then posts a failure message and the agent's work is lost. This change uses `child_process.spawn` to wait for the process to exit naturally, with no artificial ceiling.

The queue in `queue.ts` already handles the Discord UX correctly (hourglass reaction, typing indicator every 8s, per-channel sequential processing) — this change only removes the underlying process timeout.

## Test plan

- [ ] Send a message to an agent that triggers a long-running task (>5 min) and verify the response comes through
- [ ] Verify short responses still work normally
- [ ] Verify error handling: kill the maestro-cli process mid-response and confirm the bot posts an error message
- [ ] Verify non-zero exit codes with valid JSON stdout (e.g. read-only rejection) still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated command execution mechanism with improved process management, eliminating previous timeout constraints to support longer-running operations.

* **Bug Fixes**
  * Enhanced error handling for process failures with better distinction between spawn errors and exit code issues for improved recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->