### PR TITLE
Add file attachment support for Discord-to-Maestro relay

### DIFF
--- a/src/__tests__/attachments.test.ts
+++ b/src/__tests__/attachments.test.ts
@@ -1,0 +1,150 @@
+import test, { afterEach, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, readFile, stat } from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { Collection } from 'discord.js';
+import type { Attachment } from 'discord.js';
+import {
+  downloadAttachments,
+  formatAttachmentRefs,
+  MAX_FILE_SIZE,
+  FILES_DIR,
+  DownloadedFile,
+} from '../utils/attachments';
+
+// --- Helpers ---
+
+function makeAttachment(overrides: Partial<Attachment> & { name: string; url: string; size: number }): Attachment {
+  return {
+    contentType: 'application/octet-stream',
+    ...overrides,
+  } as unknown as Attachment;
+}
+
+function makeCollection(...items: Attachment[]): Collection<string, Attachment> {
+  const col = new Collection<string, Attachment>();
+  for (let i = 0; i < items.length; i++) {
+    col.set(String(i), items[i]);
+  }
+  return col;
+}
+
+function okResponse(body: string | Buffer): Response {
+  const buf = typeof body === 'string' ? Buffer.from(body) : body;
+  return {
+    ok: true,
+    status: 200,
+    arrayBuffer: () => Promise.resolve(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)),
+  } as unknown as Response;
+}
+
+function failResponse(status: number): Response {
+  return {
+    ok: false,
+    status,
+    arrayBuffer: () => Promise.reject(new Error('should not be called')),
+  } as unknown as Response;
+}
+
+// --- Test setup ---
+
+let tmpDir: string;
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), 'attachments-test-'));
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  mock.restoreAll();
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+// --- Tests ---
+
+test('downloadAttachments creates .maestro/discord-files/ directory', async () => {
+  globalThis.fetch = () => Promise.resolve(okResponse('content'));
+
+  await downloadAttachments(
+    makeCollection(makeAttachment({ name: 'test.txt', url: 'https://cdn.example.com/test.txt', size: 100 })),
+    tmpDir,
+  );
+
+  const dirStat = await stat(path.join(tmpDir, FILES_DIR));
+  assert.ok(dirStat.isDirectory());
+});
+
+test('downloadAttachments saves files with timestamp-prefixed names', async () => {
+  globalThis.fetch = () => Promise.resolve(okResponse('file content'));
+
+  const results = await downloadAttachments(
+    makeCollection(makeAttachment({ name: 'photo.png', url: 'https://cdn.example.com/photo.png', size: 500 })),
+    tmpDir,
+  );
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].originalName, 'photo.png');
+  assert.ok(results[0].savedPath.includes(FILES_DIR));
+
+  // Filename should be {timestamp}-photo.png
+  const basename = path.basename(results[0].savedPath);
+  assert.match(basename, /^\d+-photo\.png$/);
+
+  // File should contain the expected content
+  const content = await readFile(results[0].savedPath, 'utf-8');
+  assert.equal(content, 'file content');
+});
+
+test('downloadAttachments skips oversized attachments without throwing', async () => {
+  globalThis.fetch = () => {
+    throw new Error('fetch should not be called for oversized files');
+  };
+
+  const results = await downloadAttachments(
+    makeCollection(makeAttachment({ name: 'huge.bin', url: 'https://cdn.example.com/huge.bin', size: MAX_FILE_SIZE + 1 })),
+    tmpDir,
+  );
+
+  assert.equal(results.length, 0);
+});
+
+test('downloadAttachments skips failed fetches and continues', async () => {
+  let callCount = 0;
+  globalThis.fetch = () => {
+    callCount++;
+    if (callCount === 1) return Promise.resolve(failResponse(404));
+    return Promise.resolve(okResponse('second file'));
+  };
+
+  const results = await downloadAttachments(
+    makeCollection(
+      makeAttachment({ name: 'missing.txt', url: 'https://cdn.example.com/missing.txt', size: 100 }),
+      makeAttachment({ name: 'ok.txt', url: 'https://cdn.example.com/ok.txt', size: 100 }),
+    ),
+    tmpDir,
+  );
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].originalName, 'ok.txt');
+});
+
+test('downloadAttachments returns empty array for empty collection', async () => {
+  const results = await downloadAttachments(makeCollection(), tmpDir);
+  assert.deepEqual(results, []);
+});
+
+test('formatAttachmentRefs produces correct format', () => {
+  const files: DownloadedFile[] = [
+    { originalName: 'a.txt', savedPath: '/home/agent/files/123-a.txt' },
+    { originalName: 'b.png', savedPath: '/home/agent/files/456-b.png' },
+  ];
+  const result = formatAttachmentRefs(files);
+  assert.equal(result, '[Attached: /home/agent/files/123-a.txt]\n[Attached: /home/agent/files/456-b.png]');
+});
+
+test('formatAttachmentRefs returns empty string for empty array', () => {
+  assert.equal(formatAttachmentRefs([]), '');
+});

--- a/src/__tests__/attachments.test.ts
+++ b/src/__tests__/attachments.test.ts
@@ -8,6 +8,7 @@ import type { Attachment } from 'discord.js';
 import {
   downloadAttachments,
   formatAttachmentRefs,
+  cleanupAgentFiles,
   MAX_FILE_SIZE,
   FILES_DIR,
   DownloadedFile,
@@ -147,4 +148,24 @@ test('formatAttachmentRefs produces correct format', () => {
 
 test('formatAttachmentRefs returns empty string for empty array', () => {
   assert.equal(formatAttachmentRefs([]), '');
+});
+
+// --- cleanupAgentFiles tests ---
+
+test('cleanupAgentFiles removes the discord-files directory', async () => {
+  // Create the directory structure with a file inside
+  const filesDir = path.join(tmpDir, FILES_DIR);
+  const { mkdir, writeFile } = await import('fs/promises');
+  await mkdir(filesDir, { recursive: true });
+  await writeFile(path.join(filesDir, 'test.txt'), 'content');
+
+  await cleanupAgentFiles(tmpDir);
+
+  // Directory should no longer exist
+  await assert.rejects(() => stat(path.join(tmpDir, FILES_DIR)), { code: 'ENOENT' });
+});
+
+test('cleanupAgentFiles does not throw if directory does not exist', async () => {
+  // tmpDir exists but has no .maestro/discord-files/ subdirectory
+  await assert.doesNotReject(() => cleanupAgentFiles(tmpDir));
 });

--- a/src/__tests__/attachments.test.ts
+++ b/src/__tests__/attachments.test.ts
@@ -1,6 +1,6 @@
 import test, { afterEach, beforeEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, readFile, stat } from 'fs/promises';
+import { mkdtemp, rm, readFile, stat, mkdir, writeFile } from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { Collection } from 'discord.js';
@@ -161,7 +161,6 @@ test('formatAttachmentRefs returns empty string for empty array', () => {
 test('cleanupAgentFiles removes the discord-files directory', async () => {
   // Create the directory structure with a file inside
   const filesDir = path.join(tmpDir, FILES_DIR);
-  const { mkdir, writeFile } = await import('fs/promises');
   await mkdir(filesDir, { recursive: true });
   await writeFile(path.join(filesDir, 'test.txt'), 'content');
 

--- a/src/__tests__/attachments.test.ts
+++ b/src/__tests__/attachments.test.ts
@@ -176,15 +176,16 @@ test('cleanupAgentFiles does not throw if directory does not exist', async () =>
 });
 
 test('downloadAttachments reports all files as failed when mkdir fails', async () => {
-  // Use an invalid path that cannot be created
-  const invalidCwd = '/dev/null/impossible';
+  // Use a file path as cwd so mkdir(<file>/...) fails deterministically
+  const fileAsCwd = path.join(tmpDir, 'not-a-directory');
+  await writeFile(fileAsCwd, 'x');
 
   const { downloaded, failed } = await downloadAttachments(
     makeCollection(
       makeAttachment({ name: 'a.txt', url: 'https://cdn.example.com/a.txt', size: 100 }),
       makeAttachment({ name: 'b.txt', url: 'https://cdn.example.com/b.txt', size: 100 }),
     ),
-    invalidCwd,
+    fileAsCwd,
   );
 
   assert.equal(downloaded.length, 0);

--- a/src/__tests__/attachments.test.ts
+++ b/src/__tests__/attachments.test.ts
@@ -12,6 +12,7 @@ import {
   MAX_FILE_SIZE,
   FILES_DIR,
   DownloadedFile,
+  DownloadResult,
 } from '../utils/attachments';
 
 // --- Helpers ---
@@ -69,50 +70,54 @@ afterEach(async () => {
 test('downloadAttachments creates .maestro/discord-files/ directory', async () => {
   globalThis.fetch = () => Promise.resolve(okResponse('content'));
 
-  await downloadAttachments(
+  const result = await downloadAttachments(
     makeCollection(makeAttachment({ name: 'test.txt', url: 'https://cdn.example.com/test.txt', size: 100 })),
     tmpDir,
   );
 
   const dirStat = await stat(path.join(tmpDir, FILES_DIR));
   assert.ok(dirStat.isDirectory());
+  assert.equal(result.downloaded.length, 1);
+  assert.deepEqual(result.failed, []);
 });
 
-test('downloadAttachments saves files with timestamp-prefixed names', async () => {
+test('downloadAttachments saves files with UUID-prefixed names', async () => {
   globalThis.fetch = () => Promise.resolve(okResponse('file content'));
 
-  const results = await downloadAttachments(
+  const { downloaded, failed } = await downloadAttachments(
     makeCollection(makeAttachment({ name: 'photo.png', url: 'https://cdn.example.com/photo.png', size: 500 })),
     tmpDir,
   );
 
-  assert.equal(results.length, 1);
-  assert.equal(results[0].originalName, 'photo.png');
-  assert.ok(results[0].savedPath.includes(FILES_DIR));
+  assert.equal(downloaded.length, 1);
+  assert.deepEqual(failed, []);
+  assert.equal(downloaded[0].originalName, 'photo.png');
+  assert.ok(downloaded[0].savedPath.includes(FILES_DIR));
 
-  // Filename should be {timestamp}-photo.png
-  const basename = path.basename(results[0].savedPath);
-  assert.match(basename, /^\d+-photo\.png$/);
+  // Filename should be {uuid}-photo.png
+  const basename = path.basename(downloaded[0].savedPath);
+  assert.match(basename, /^[0-9a-f-]{36}-photo\.png$/);
 
   // File should contain the expected content
-  const content = await readFile(results[0].savedPath, 'utf-8');
+  const content = await readFile(downloaded[0].savedPath, 'utf-8');
   assert.equal(content, 'file content');
 });
 
-test('downloadAttachments skips oversized attachments without throwing', async () => {
+test('downloadAttachments skips oversized attachments and reports them as failed', async () => {
   globalThis.fetch = () => {
     throw new Error('fetch should not be called for oversized files');
   };
 
-  const results = await downloadAttachments(
+  const { downloaded, failed } = await downloadAttachments(
     makeCollection(makeAttachment({ name: 'huge.bin', url: 'https://cdn.example.com/huge.bin', size: MAX_FILE_SIZE + 1 })),
     tmpDir,
   );
 
-  assert.equal(results.length, 0);
+  assert.equal(downloaded.length, 0);
+  assert.deepEqual(failed, ['huge.bin']);
 });
 
-test('downloadAttachments skips failed fetches and continues', async () => {
+test('downloadAttachments skips failed fetches, reports them, and continues', async () => {
   let callCount = 0;
   globalThis.fetch = () => {
     callCount++;
@@ -120,7 +125,7 @@ test('downloadAttachments skips failed fetches and continues', async () => {
     return Promise.resolve(okResponse('second file'));
   };
 
-  const results = await downloadAttachments(
+  const { downloaded, failed } = await downloadAttachments(
     makeCollection(
       makeAttachment({ name: 'missing.txt', url: 'https://cdn.example.com/missing.txt', size: 100 }),
       makeAttachment({ name: 'ok.txt', url: 'https://cdn.example.com/ok.txt', size: 100 }),
@@ -128,13 +133,14 @@ test('downloadAttachments skips failed fetches and continues', async () => {
     tmpDir,
   );
 
-  assert.equal(results.length, 1);
-  assert.equal(results[0].originalName, 'ok.txt');
+  assert.equal(downloaded.length, 1);
+  assert.equal(downloaded[0].originalName, 'ok.txt');
+  assert.deepEqual(failed, ['missing.txt']);
 });
 
-test('downloadAttachments returns empty array for empty collection', async () => {
-  const results = await downloadAttachments(makeCollection(), tmpDir);
-  assert.deepEqual(results, []);
+test('downloadAttachments returns empty result for empty collection', async () => {
+  const result = await downloadAttachments(makeCollection(), tmpDir);
+  assert.deepEqual(result, { downloaded: [], failed: [] });
 });
 
 test('formatAttachmentRefs produces correct format', () => {
@@ -168,4 +174,43 @@ test('cleanupAgentFiles removes the discord-files directory', async () => {
 test('cleanupAgentFiles does not throw if directory does not exist', async () => {
   // tmpDir exists but has no .maestro/discord-files/ subdirectory
   await assert.doesNotReject(() => cleanupAgentFiles(tmpDir));
+});
+
+test('downloadAttachments reports all files as failed when mkdir fails', async () => {
+  // Use an invalid path that cannot be created
+  const invalidCwd = '/dev/null/impossible';
+
+  const { downloaded, failed } = await downloadAttachments(
+    makeCollection(
+      makeAttachment({ name: 'a.txt', url: 'https://cdn.example.com/a.txt', size: 100 }),
+      makeAttachment({ name: 'b.txt', url: 'https://cdn.example.com/b.txt', size: 100 }),
+    ),
+    invalidCwd,
+  );
+
+  assert.equal(downloaded.length, 0);
+  assert.deepEqual(failed, ['a.txt', 'b.txt']);
+});
+
+test('downloadAttachments handles partial failures — downloads successes and reports failures', async () => {
+  let callCount = 0;
+  globalThis.fetch = () => {
+    callCount++;
+    if (callCount === 2) return Promise.reject(new Error('network error'));
+    return Promise.resolve(okResponse(`content-${callCount}`));
+  };
+
+  const { downloaded, failed } = await downloadAttachments(
+    makeCollection(
+      makeAttachment({ name: 'first.txt', url: 'https://cdn.example.com/first.txt', size: 100 }),
+      makeAttachment({ name: 'broken.txt', url: 'https://cdn.example.com/broken.txt', size: 100 }),
+      makeAttachment({ name: 'third.txt', url: 'https://cdn.example.com/third.txt', size: 100 }),
+    ),
+    tmpDir,
+  );
+
+  assert.equal(downloaded.length, 2);
+  assert.equal(downloaded[0].originalName, 'first.txt');
+  assert.equal(downloaded[1].originalName, 'third.txt');
+  assert.deepEqual(failed, ['broken.txt']);
 });

--- a/src/__tests__/getAgentCwd.test.ts
+++ b/src/__tests__/getAgentCwd.test.ts
@@ -1,0 +1,51 @@
+import test, { afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { maestro, resetAgentCwdCache, AGENT_CWD_CACHE_TTL } from '../services/maestro';
+import type { MaestroAgent } from '../services/maestro';
+
+const fakeAgents: MaestroAgent[] = [
+  { id: 'agent-1', name: 'Agent One', toolType: 'claude', cwd: '/home/user/project-a' },
+  { id: 'agent-2', name: 'Agent Two', toolType: 'claude', cwd: '/home/user/project-b' },
+];
+
+afterEach(() => {
+  mock.restoreAll();
+  resetAgentCwdCache();
+});
+
+test('getAgentCwd returns the correct cwd for a known agent', async () => {
+  mock.method(maestro, 'listAgents', async () => fakeAgents);
+
+  const cwd = await maestro.getAgentCwd('agent-1');
+  assert.equal(cwd, '/home/user/project-a');
+});
+
+test('getAgentCwd returns null for an unknown agent', async () => {
+  mock.method(maestro, 'listAgents', async () => fakeAgents);
+
+  const cwd = await maestro.getAgentCwd('nonexistent');
+  assert.equal(cwd, null);
+});
+
+test('getAgentCwd caches results and does not re-invoke listAgents within TTL', async () => {
+  const listAgentsMock = mock.method(maestro, 'listAgents', async () => fakeAgents);
+
+  await maestro.getAgentCwd('agent-1');
+  await maestro.getAgentCwd('agent-2');
+  await maestro.getAgentCwd('agent-1');
+
+  assert.equal(listAgentsMock.mock.callCount(), 1);
+});
+
+test('getAgentCwd refreshes cache after TTL expires', async () => {
+  const listAgentsMock = mock.method(maestro, 'listAgents', async () => fakeAgents);
+
+  await maestro.getAgentCwd('agent-1');
+  assert.equal(listAgentsMock.mock.callCount(), 1);
+
+  // Simulate TTL expiry by resetting cache
+  resetAgentCwdCache();
+
+  await maestro.getAgentCwd('agent-2');
+  assert.equal(listAgentsMock.mock.callCount(), 2);
+});

--- a/src/__tests__/getAgentCwd.test.ts
+++ b/src/__tests__/getAgentCwd.test.ts
@@ -49,3 +49,28 @@ test('getAgentCwd refreshes cache after TTL expires', async () => {
   await maestro.getAgentCwd('agent-2');
   assert.equal(listAgentsMock.mock.callCount(), 2);
 });
+
+test('getAgentCwd propagates errors from listAgents', async () => {
+  mock.method(maestro, 'listAgents', async () => {
+    throw new Error('CLI not found');
+  });
+
+  await assert.rejects(() => maestro.getAgentCwd('agent-1'), { message: 'CLI not found' });
+});
+
+test('getAgentCwd retries after a failed listAgents call', async () => {
+  let callCount = 0;
+  mock.method(maestro, 'listAgents', async () => {
+    callCount++;
+    if (callCount === 1) throw new Error('transient failure');
+    return fakeAgents;
+  });
+
+  // First call fails
+  await assert.rejects(() => maestro.getAgentCwd('agent-1'), { message: 'transient failure' });
+
+  // Cache was not set, so next call should retry listAgents
+  const cwd = await maestro.getAgentCwd('agent-1');
+  assert.equal(cwd, '/home/user/project-a');
+  assert.equal(callCount, 2);
+});

--- a/src/__tests__/getAgentCwd.test.ts
+++ b/src/__tests__/getAgentCwd.test.ts
@@ -1,6 +1,6 @@
 import test, { afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { maestro, resetAgentCwdCache, AGENT_CWD_CACHE_TTL } from '../services/maestro';
+import { maestro, resetAgentCwdCache } from '../services/maestro';
 import type { MaestroAgent } from '../services/maestro';
 
 const fakeAgents: MaestroAgent[] = [

--- a/src/__tests__/messageCreate.test.ts
+++ b/src/__tests__/messageCreate.test.ts
@@ -8,6 +8,7 @@ function makeMessage(overrides: Partial<Record<string, unknown>> = {}) {
     member: { displayName: 'Test User' },
     guild: { id: 'guild-1' },
     content: 'hello',
+    attachments: { size: 0, values: () => [] },
     mentions: { users: { has: () => false } },
     channel: {
       id: 'thread-1',
@@ -45,12 +46,23 @@ test('handleMessageCreate ignores DMs', async () => {
   assert.equal(enqueued, 0);
 });
 
-test('handleMessageCreate ignores empty messages', async () => {
+test('handleMessageCreate ignores messages with no text and no attachments', async () => {
   let enqueued = 0;
   const handler = createMessageCreateHandler(createDeps(() => { enqueued += 1; }));
 
-  await handler(makeMessage({ content: '   ' }) as any);
+  await handler(makeMessage({ content: '   ', attachments: { size: 0, values: () => [] } }) as any);
   assert.equal(enqueued, 0);
+});
+
+test('handleMessageCreate allows attachment-only messages (no text)', async () => {
+  let enqueued = 0;
+  const handler = createMessageCreateHandler(createDeps(() => { enqueued += 1; }));
+
+  await handler(makeMessage({
+    content: '',
+    attachments: { size: 1, values: () => [{ url: 'https://example.com/file.png', name: 'file.png' }] },
+  }) as any);
+  assert.equal(enqueued, 1);
 });
 
 test('handleMessageCreate ignores non-thread channels', async () => {
@@ -124,9 +136,10 @@ test('handleMessageCreate creates and registers a thread for bot mentions in reg
             assert.ok(name.includes('Test-User'));
             return {
               id: 'thread-new-1',
-              send: async (text: string) => {
+              send: async (msg: string | { content?: string; files?: string[] }) => {
+                const text = typeof msg === 'string' ? msg : (msg.content ?? '');
                 sentMessages.push(text);
-                return { id: 'msg-forwarded', content: text };
+                return { id: 'msg-forwarded', content: text, attachments: { size: 0, values: () => [] } };
               },
             };
           },
@@ -158,7 +171,10 @@ test('handleMessageCreate creates and registers a thread when mention metadata i
         threads: {
           create: async () => ({
             id: 'thread-new-2',
-            send: async (text: string) => ({ id: 'msg-fwd', content: text }),
+            send: async (msg: string | { content?: string; files?: string[] }) => {
+              const text = typeof msg === 'string' ? msg : (msg.content ?? '');
+              return { id: 'msg-fwd', content: text, attachments: { size: 0, values: () => [] } };
+            },
           }),
         },
       },

--- a/src/__tests__/messageCreate.test.ts
+++ b/src/__tests__/messageCreate.test.ts
@@ -18,7 +18,7 @@ function makeMessage(overrides: Partial<Record<string, unknown>> = {}) {
   } as unknown;
 }
 
-function createDeps(enqueue: () => void) {
+function createDeps(enqueue: (...args: any[]) => void) {
   return {
     channelDb: { get: () => ({ agent_id: 'agent-1' }) as any },
     threadDb: {
@@ -182,6 +182,63 @@ test('handleMessageCreate creates and registers a thread when mention metadata i
   );
 
   assert.deepEqual(registerCalls, [['thread-new-2', 'channel-1', 'agent-1', 'user-42']]);
+});
+
+test('handleMessageCreate forwards attachments as AttachmentPayload objects in mention-triggered threads', async () => {
+  let enqueued = 0;
+  let enqueuedMessage: any = null;
+  const deps = createDeps((msg: any) => { enqueued += 1; enqueuedMessage = msg; });
+  deps.threadDb.register = () => undefined;
+
+  const handler = createMessageCreateHandler(deps as any);
+  await handler(
+    makeMessage({
+      content: 'check this <@bot-1>',
+      attachments: {
+        size: 1,
+        values: () => [
+          { url: 'https://cdn.discord.com/file.png', name: 'file.png', size: 500 },
+        ],
+      },
+      channel: {
+        id: 'channel-1',
+        isThread: () => false,
+        threads: {
+          create: async () => ({
+            id: 'thread-att-1',
+            send: async (msg: string | { content?: string; files?: unknown[] }) => {
+              if (typeof msg !== 'string' && msg.files) {
+                // Verify files are sent as AttachmentPayload objects, not bare URLs
+                assert.ok(Array.isArray(msg.files));
+                for (const f of msg.files) {
+                  assert.ok(typeof f === 'object' && f !== null);
+                  assert.ok('attachment' in (f as any), 'file should have attachment property');
+                  assert.ok('name' in (f as any), 'file should have name property');
+                }
+              }
+              return {
+                id: 'msg-att-forwarded',
+                content: typeof msg === 'string' ? msg : (msg.content ?? ''),
+                // Simulate discord.js: when sent with AttachmentPayload, the
+                // returned message should have real attachments
+                attachments: {
+                  size: 1,
+                  values: () => [
+                    { url: 'https://cdn.discord.com/reupload/file.png', name: 'file.png', size: 500 },
+                  ],
+                },
+              };
+            },
+          }),
+        },
+      },
+    }) as any
+  );
+
+  assert.equal(enqueued, 1);
+  // The enqueued message should have real attachments (not size 0)
+  assert.ok(enqueuedMessage);
+  assert.equal(enqueuedMessage.attachments.size, 1);
 });
 
 test('handleMessageCreate ignores non-thread channel messages without bot mention', async () => {

--- a/src/__tests__/queue.test.ts
+++ b/src/__tests__/queue.test.ts
@@ -168,8 +168,8 @@ test('queue handles attachment download failure gracefully', async () => {
   await settle();
 
   // Should log the error
-  assert.equal((deps.logger.error as ReturnType<typeof mock.fn>).mock.callCount(), 1);
-  const logArgs = (deps.logger.error as ReturnType<typeof mock.fn>).mock.calls[0].arguments;
+  assert.equal((deps.logger.error as unknown as ReturnType<typeof mock.fn>).mock.callCount(), 1);
+  const logArgs = (deps.logger.error as unknown as ReturnType<typeof mock.fn>).mock.calls[0].arguments;
   assert.equal(logArgs[0], 'queue:attachment-download');
   assert.ok((logArgs[1] as string).includes('Network timeout'));
 

--- a/src/__tests__/queue.test.ts
+++ b/src/__tests__/queue.test.ts
@@ -149,6 +149,44 @@ test('queue sends only attachment refs when message content is empty', async () 
   assert.equal(sentMessage, '[Attached: /home/agent/.maestro/discord-files/456-img.png]');
 });
 
+test('queue handles attachment download failure gracefully', async () => {
+  const deps = createMockDeps();
+  deps._mocks.download.mock.mockImplementation(async () => {
+    throw new Error('Network timeout');
+  });
+
+  const { enqueue } = createQueue(deps);
+  const msg = makeMessage({
+    content: 'check this file',
+    attachments: {
+      size: 1,
+      values: () => [{ url: 'https://cdn.example.com/file.txt', name: 'file.txt', size: 100 }],
+    },
+  });
+
+  enqueue(msg);
+  await settle();
+
+  // Should log the error
+  assert.equal((deps.logger.error as ReturnType<typeof mock.fn>).mock.callCount(), 1);
+  const logArgs = (deps.logger.error as ReturnType<typeof mock.fn>).mock.calls[0].arguments;
+  assert.equal(logArgs[0], 'queue:attachment-download');
+  assert.ok((logArgs[1] as string).includes('Network timeout'));
+
+  // Should warn the user
+  const sendCalls = msg.channel.send.mock.calls;
+  const warningCall = sendCalls.find(
+    (c: { arguments: unknown[] }) =>
+      typeof c.arguments[0] === 'string' &&
+      c.arguments[0].includes('Failed to download one or more attachments'),
+  );
+  assert.ok(warningCall, 'Expected a warning about failed downloads');
+
+  // Should still send the message text to the agent (without attachment refs)
+  assert.equal(deps._mocks.send.mock.callCount(), 1);
+  assert.equal(deps._mocks.send.mock.calls[0].arguments[1], 'check this file');
+});
+
 test('queue warns when agent cwd cannot be resolved for attachments', async () => {
   const deps = createMockDeps();
   deps._mocks.getAgentCwd.mock.mockImplementation(async () => null);

--- a/src/__tests__/queue.test.ts
+++ b/src/__tests__/queue.test.ts
@@ -32,7 +32,7 @@ function defaultSendResult(extra: Record<string, unknown> = {}) {
 function createMockDeps(): QueueDeps & { _mocks: Record<string, ReturnType<typeof mock.fn>> } {
   const mockGetAgentCwd = mock.fn(async () => '/home/agent' as string | null);
   const mockSend = mock.fn(async () => defaultSendResult());
-  const mockDownload = mock.fn(async () => [] as { originalName: string; savedPath: string }[]);
+  const mockDownload = mock.fn(async () => ({ downloaded: [] as { originalName: string; savedPath: string }[], failed: [] as string[] }));
   const mockFormat = mock.fn(() => '');
   const mockLoggerError = mock.fn();
   const mockChannelGet = mock.fn(() => ({
@@ -71,9 +71,12 @@ const settle = () => new Promise((r) => setTimeout(r, 50));
 
 test('queue calls downloadAttachments when message has attachments', async () => {
   const deps = createMockDeps();
-  const attachmentData = [
-    { originalName: 'file.txt', savedPath: '/home/agent/.maestro/discord-files/123-file.txt' },
-  ];
+  const attachmentData = {
+    downloaded: [
+      { originalName: 'file.txt', savedPath: '/home/agent/.maestro/discord-files/123-file.txt' },
+    ],
+    failed: [],
+  };
   deps._mocks.download.mock.mockImplementation(async () => attachmentData);
   deps._mocks.format.mock.mockImplementation(
     () => '[Attached: /home/agent/.maestro/discord-files/123-file.txt]',
@@ -125,9 +128,12 @@ test('queue does not call downloadAttachments when message has no attachments', 
 
 test('queue sends only attachment refs when message content is empty', async () => {
   const deps = createMockDeps();
-  deps._mocks.download.mock.mockImplementation(async () => [
-    { originalName: 'img.png', savedPath: '/home/agent/.maestro/discord-files/456-img.png' },
-  ]);
+  deps._mocks.download.mock.mockImplementation(async () => ({
+    downloaded: [
+      { originalName: 'img.png', savedPath: '/home/agent/.maestro/discord-files/456-img.png' },
+    ],
+    failed: [],
+  }));
   deps._mocks.format.mock.mockImplementation(
     () => '[Attached: /home/agent/.maestro/discord-files/456-img.png]',
   );
@@ -178,13 +184,57 @@ test('queue handles attachment download failure gracefully', async () => {
   const warningCall = sendCalls.find(
     (c: { arguments: unknown[] }) =>
       typeof c.arguments[0] === 'string' &&
-      c.arguments[0].includes('Failed to download one or more attachments'),
+      c.arguments[0].includes('Failed to download attachments'),
   );
   assert.ok(warningCall, 'Expected a warning about failed downloads');
 
   // Should still send the message text to the agent (without attachment refs)
   assert.equal(deps._mocks.send.mock.callCount(), 1);
   assert.equal(deps._mocks.send.mock.calls[0].arguments[1], 'check this file');
+});
+
+test('queue shows specific file names when some downloads fail', async () => {
+  const deps = createMockDeps();
+  deps._mocks.download.mock.mockImplementation(async () => ({
+    downloaded: [
+      { originalName: 'ok.txt', savedPath: '/home/agent/.maestro/discord-files/ok.txt' },
+    ],
+    failed: ['broken.png', 'huge.bin'],
+  }));
+  deps._mocks.format.mock.mockImplementation(
+    () => '[Attached: /home/agent/.maestro/discord-files/ok.txt]',
+  );
+
+  const { enqueue } = createQueue(deps);
+  const msg = makeMessage({
+    content: 'files here',
+    attachments: {
+      size: 3,
+      values: () => [
+        { url: 'u1', name: 'ok.txt', size: 100 },
+        { url: 'u2', name: 'broken.png', size: 100 },
+        { url: 'u3', name: 'huge.bin', size: 100 },
+      ],
+    },
+  });
+
+  enqueue(msg);
+  await settle();
+
+  // Should warn about the specific failed files
+  const sendCalls = msg.channel.send.mock.calls;
+  const warningCall = sendCalls.find(
+    (c: { arguments: unknown[] }) =>
+      typeof c.arguments[0] === 'string' &&
+      c.arguments[0].includes('broken.png') &&
+      c.arguments[0].includes('huge.bin'),
+  );
+  assert.ok(warningCall, 'Expected a warning naming the failed files');
+
+  // Should still send the message with the successful attachment ref
+  assert.equal(deps._mocks.send.mock.callCount(), 1);
+  const sentMessage = deps._mocks.send.mock.calls[0].arguments[1];
+  assert.ok((sentMessage as string).includes('[Attached:'));
 });
 
 test('queue warns when agent cwd cannot be resolved for attachments', async () => {

--- a/src/__tests__/queue.test.ts
+++ b/src/__tests__/queue.test.ts
@@ -1,0 +1,179 @@
+import test, { beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { createQueue, QueueDeps } from '../services/queueFactory';
+
+// --- Helpers ---
+
+function makeMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    content: 'hello',
+    attachments: { size: 0, values: () => [] },
+    channel: {
+      id: 'thread-1',
+      isThread: () => true,
+      send: mock.fn(async () => {}),
+      sendTyping: mock.fn(async () => {}),
+    },
+    react: mock.fn(async () => ({ remove: mock.fn(async () => {}) })),
+    ...overrides,
+  } as any;
+}
+
+function defaultSendResult(extra: Record<string, unknown> = {}) {
+  return {
+    success: true,
+    response: 'Agent response',
+    sessionId: 'session-1',
+    usage: { inputTokens: 100, outputTokens: 50, totalCostUsd: 0.001, contextUsagePercent: 5 },
+    ...extra,
+  };
+}
+
+function createMockDeps(): QueueDeps & { _mocks: Record<string, ReturnType<typeof mock.fn>> } {
+  const mockGetAgentCwd = mock.fn(async () => '/home/agent' as string | null);
+  const mockSend = mock.fn(async () => defaultSendResult());
+  const mockDownload = mock.fn(async () => [] as { originalName: string; savedPath: string }[]);
+  const mockFormat = mock.fn(() => '');
+  const mockLoggerError = mock.fn();
+  const mockChannelGet = mock.fn(() => ({
+    channel_id: 'channel-1',
+    agent_id: 'agent-1',
+    session_id: 'session-1',
+  }) as any);
+  const mockThreadGet = mock.fn(() => ({
+    thread_id: 'thread-1',
+    channel_id: 'channel-1',
+    agent_id: 'agent-1',
+    session_id: 'session-1',
+  }) as any);
+
+  return {
+    maestro: { getAgentCwd: mockGetAgentCwd as any, send: mockSend as any },
+    channelDb: { get: mockChannelGet as any, updateSession: mock.fn() },
+    threadDb: { get: mockThreadGet as any, updateSession: mock.fn() },
+    splitMessage: (text: string) => [text],
+    downloadAttachments: mockDownload as any,
+    formatAttachmentRefs: mockFormat as any,
+    logger: { error: mockLoggerError as any },
+    _mocks: {
+      getAgentCwd: mockGetAgentCwd,
+      send: mockSend,
+      download: mockDownload,
+      format: mockFormat,
+    },
+  };
+}
+
+// Allow async queue processing to settle
+const settle = () => new Promise((r) => setTimeout(r, 50));
+
+// --- Tests ---
+
+test('queue calls downloadAttachments when message has attachments', async () => {
+  const deps = createMockDeps();
+  const attachmentData = [
+    { originalName: 'file.txt', savedPath: '/home/agent/.maestro/discord-files/123-file.txt' },
+  ];
+  deps._mocks.download.mock.mockImplementation(async () => attachmentData);
+  deps._mocks.format.mock.mockImplementation(
+    () => '[Attached: /home/agent/.maestro/discord-files/123-file.txt]',
+  );
+
+  const { enqueue } = createQueue(deps);
+  const msg = makeMessage({
+    content: 'check this file',
+    attachments: {
+      size: 1,
+      values: () => [{ url: 'https://cdn.example.com/file.txt', name: 'file.txt', size: 100 }],
+    },
+  });
+
+  enqueue(msg);
+  await settle();
+
+  // downloadAttachments should have been called
+  assert.equal(deps._mocks.download.mock.callCount(), 1);
+  assert.equal(deps._mocks.getAgentCwd.mock.callCount(), 1);
+  assert.equal(deps._mocks.getAgentCwd.mock.calls[0].arguments[0], 'agent-1');
+
+  // formatAttachmentRefs should have been called with the downloaded files
+  assert.equal(deps._mocks.format.mock.callCount(), 1);
+
+  // maestro.send should receive the combined message
+  assert.equal(deps._mocks.send.mock.callCount(), 1);
+  const sentMessage = deps._mocks.send.mock.calls[0].arguments[1];
+  assert.equal(
+    sentMessage,
+    'check this file\n\n[Attached: /home/agent/.maestro/discord-files/123-file.txt]',
+  );
+});
+
+test('queue does not call downloadAttachments when message has no attachments', async () => {
+  const deps = createMockDeps();
+  const { enqueue } = createQueue(deps);
+
+  enqueue(makeMessage({ content: 'just text', attachments: { size: 0, values: () => [] } }));
+  await settle();
+
+  assert.equal(deps._mocks.download.mock.callCount(), 0);
+  assert.equal(deps._mocks.getAgentCwd.mock.callCount(), 0);
+
+  // maestro.send should receive only the text content
+  assert.equal(deps._mocks.send.mock.callCount(), 1);
+  assert.equal(deps._mocks.send.mock.calls[0].arguments[1], 'just text');
+});
+
+test('queue sends only attachment refs when message content is empty', async () => {
+  const deps = createMockDeps();
+  deps._mocks.download.mock.mockImplementation(async () => [
+    { originalName: 'img.png', savedPath: '/home/agent/.maestro/discord-files/456-img.png' },
+  ]);
+  deps._mocks.format.mock.mockImplementation(
+    () => '[Attached: /home/agent/.maestro/discord-files/456-img.png]',
+  );
+
+  const { enqueue } = createQueue(deps);
+  enqueue(
+    makeMessage({
+      content: '',
+      attachments: {
+        size: 1,
+        values: () => [{ url: 'https://cdn.example.com/img.png', name: 'img.png', size: 200 }],
+      },
+    }),
+  );
+  await settle();
+
+  assert.equal(deps._mocks.send.mock.callCount(), 1);
+  const sentMessage = deps._mocks.send.mock.calls[0].arguments[1];
+  assert.equal(sentMessage, '[Attached: /home/agent/.maestro/discord-files/456-img.png]');
+});
+
+test('queue warns when agent cwd cannot be resolved for attachments', async () => {
+  const deps = createMockDeps();
+  deps._mocks.getAgentCwd.mock.mockImplementation(async () => null);
+
+  const { enqueue } = createQueue(deps);
+  const msg = makeMessage({
+    content: 'here is a file',
+    attachments: {
+      size: 1,
+      values: () => [{ url: 'https://cdn.example.com/file.txt', name: 'file.txt', size: 100 }],
+    },
+  });
+
+  enqueue(msg);
+  await settle();
+
+  // downloadAttachments should NOT be called if cwd is null
+  assert.equal(deps._mocks.download.mock.callCount(), 0);
+
+  // Channel should receive a warning message
+  const sendCalls = msg.channel.send.mock.calls;
+  const warningCall = sendCalls.find(
+    (c: { arguments: unknown[] }) =>
+      typeof c.arguments[0] === 'string' &&
+      c.arguments[0].includes('Could not resolve agent working directory'),
+  );
+  assert.ok(warningCall, 'Expected a warning about unresolved agent cwd');
+});

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -7,7 +7,7 @@ import {
   TextChannel,
 } from 'discord.js';
 import { maestro } from '../services/maestro';
-import { channelDb } from '../db';
+import { channelDb, threadDb } from '../db';
 import { cleanupAgentFiles } from '../utils/attachments';
 
 export const data = new SlashCommandBuilder()
@@ -199,12 +199,16 @@ async function handleDisconnect(interaction: ChatInputCommandInteraction): Promi
   await interaction.reply({ content: `Disconnecting **${channelInfo.agent_name}**...`, ephemeral: true });
 
   // Clean up downloaded files if this is the last channel for this agent
+  // (also consider threads bound to other channels for the same agent)
   const agentId = channelInfo.agent_id;
   const otherChannels = channelDb.getByAgentId(agentId).filter(
     (c) => c.channel_id !== interaction.channelId,
   );
+  const otherThreads = threadDb.getByAgentId(agentId).filter(
+    (t) => t.channel_id !== interaction.channelId,
+  );
 
-  if (otherChannels.length === 0) {
+  if (otherChannels.length === 0 && otherThreads.length === 0) {
     try {
       const agentCwd = await maestro.getAgentCwd(agentId);
       if (agentCwd) {
@@ -215,9 +219,11 @@ async function handleDisconnect(interaction: ChatInputCommandInteraction): Promi
       console.warn(`[disconnect] Failed to clean up files for agent ${agentId}:`, err);
     }
   } else {
-    console.log(`[disconnect] Skipping file cleanup for agent ${agentId} — ${otherChannels.length} other channel(s) still active`);
+    console.log(`[disconnect] Skipping file cleanup for agent ${agentId} — ${otherChannels.length} other channel(s) and ${otherThreads.length} other thread(s) still active`);
   }
 
+  // Remove channel and its threads from DB
+  threadDb.removeByChannel(interaction.channelId);
   channelDb.remove(interaction.channelId);
 
   setTimeout(async () => {

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -8,6 +8,7 @@ import {
 } from 'discord.js';
 import { maestro } from '../services/maestro';
 import { channelDb } from '../db';
+import { cleanupAgentFiles } from '../utils/attachments';
 
 export const data = new SlashCommandBuilder()
   .setName('agents')
@@ -196,6 +197,27 @@ async function handleDisconnect(interaction: ChatInputCommandInteraction): Promi
   }
 
   await interaction.reply({ content: `Disconnecting **${channelInfo.agent_name}**...`, ephemeral: true });
+
+  // Clean up downloaded files if this is the last channel for this agent
+  const agentId = channelInfo.agent_id;
+  const otherChannels = channelDb.getByAgentId(agentId).filter(
+    (c) => c.channel_id !== interaction.channelId,
+  );
+
+  if (otherChannels.length === 0) {
+    try {
+      const agentCwd = await maestro.getAgentCwd(agentId);
+      if (agentCwd) {
+        await cleanupAgentFiles(agentCwd);
+        console.log(`[disconnect] Cleaned up files for agent ${agentId}`);
+      }
+    } catch (err) {
+      console.warn(`[disconnect] Failed to clean up files for agent ${agentId}:`, err);
+    }
+  } else {
+    console.log(`[disconnect] Skipping file cleanup for agent ${agentId} — ${otherChannels.length} other channel(s) still active`);
+  }
+
   channelDb.remove(interaction.channelId);
 
   setTimeout(async () => {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -111,4 +111,13 @@ export const threadDb = {
   remove(threadId: string): void {
     db.prepare('DELETE FROM agent_threads WHERE thread_id = ?').run(threadId);
   },
+
+  getByAgentId(agentId: string): AgentThread[] {
+    return db.prepare('SELECT * FROM agent_threads WHERE agent_id = ?')
+      .all(agentId) as AgentThread[];
+  },
+
+  removeByChannel(channelId: string): void {
+    db.prepare('DELETE FROM agent_threads WHERE channel_id = ?').run(channelId);
+  },
 };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -65,6 +65,11 @@ export const channelDb = {
     db.prepare('DELETE FROM agent_channels WHERE channel_id = ?').run(channelId);
   },
 
+  getByAgentId(agentId: string): AgentChannel[] {
+    return db.prepare('SELECT * FROM agent_channels WHERE agent_id = ?')
+      .all(agentId) as AgentChannel[];
+  },
+
   listByGuild(guildId: string): AgentChannel[] {
     return db.prepare('SELECT * FROM agent_channels WHERE guild_id = ?')
       .all(guildId) as AgentChannel[];

--- a/src/handlers/messageCreate.ts
+++ b/src/handlers/messageCreate.ts
@@ -16,8 +16,8 @@ export function createMessageCreateHandler(deps: MessageCreateDeps) {
     if (message.author.bot) return;
     if (!message.guild) return;
 
-    // Ignore empty messages (e.g. attachments-only)
-    if (!message.content.trim()) return;
+    // Ignore empty messages (no text and no attachments)
+    if (!message.content.trim() && message.attachments.size === 0) return;
 
     const botUserId = deps.getBotUserId(message);
     if (!botUserId) {
@@ -68,8 +68,11 @@ export function createMessageCreateHandler(deps: MessageCreateDeps) {
           ? new RegExp(`<@!?${botUserId}>|<@&${botRoleId}>`, 'g')
           : new RegExp(`<@!?${botUserId}>`, 'g');
         const cleanContent = message.content.replace(mentionPattern, '').trim();
-        if (cleanContent) {
-          const threadMessage = await thread.send(cleanContent);
+        if (cleanContent || message.attachments.size > 0) {
+          const threadMessage = await thread.send({
+            content: cleanContent || undefined,
+            files: [...message.attachments.values()].map(a => a.url),
+          });
           deps.enqueue(threadMessage);
         }
       } catch (err) {

--- a/src/handlers/messageCreate.ts
+++ b/src/handlers/messageCreate.ts
@@ -69,9 +69,15 @@ export function createMessageCreateHandler(deps: MessageCreateDeps) {
           : new RegExp(`<@!?${botUserId}>`, 'g');
         const cleanContent = message.content.replace(mentionPattern, '').trim();
         if (cleanContent || message.attachments.size > 0) {
+          // Re-upload attachments so the thread message has real discord.js
+          // Attachment objects (sending bare URLs produces attachments.size===0).
+          const files = [...message.attachments.values()].map(a => ({
+            attachment: a.url,
+            name: a.name,
+          }));
           const threadMessage = await thread.send({
             content: cleanContent || undefined,
-            files: [...message.attachments.values()].map(a => a.url),
+            files: files.length > 0 ? files : undefined,
           });
           deps.enqueue(threadMessage);
         }

--- a/src/services/maestro.ts
+++ b/src/services/maestro.ts
@@ -143,6 +143,18 @@ function runSpawn(args: string[]): Promise<string> {
   });
 }
 
+// --- Agent CWD cache ---
+
+let agentCwdCache: Map<string, string> | null = null;
+let agentCwdCacheTime = 0;
+export const AGENT_CWD_CACHE_TTL = 60_000; // 60 seconds
+
+/** Reset the agent CWD cache (exported for testing). */
+export function resetAgentCwdCache(): void {
+  agentCwdCache = null;
+  agentCwdCacheTime = 0;
+}
+
 // --- Service ---
 
 export const maestro = {
@@ -160,6 +172,17 @@ export const maestro = {
   async listAgents(): Promise<MaestroAgent[]> {
     const raw = await run(['list', 'agents', '--json']);
     return JSON.parse(raw) as MaestroAgent[];
+  },
+
+  /** Look up an agent's cwd by ID, with a TTL cache to avoid repeated CLI calls. */
+  async getAgentCwd(agentId: string): Promise<string | null> {
+    const now = Date.now();
+    if (!agentCwdCache || now - agentCwdCacheTime > AGENT_CWD_CACHE_TTL) {
+      const agents = await this.listAgents();
+      agentCwdCache = new Map(agents.map(a => [a.id, a.cwd]));
+      agentCwdCacheTime = now;
+    }
+    return agentCwdCache.get(agentId) ?? null;
   },
 
   /** List sessions for a given agent */

--- a/src/services/queue.ts
+++ b/src/services/queue.ts
@@ -2,6 +2,7 @@ import { Message, TextChannel, ThreadChannel } from 'discord.js';
 import { maestro } from './maestro';
 import { channelDb, threadDb } from '../db';
 import { splitMessage } from '../utils/splitMessage';
+import { downloadAttachments, formatAttachmentRefs } from '../utils/attachments';
 import { logger } from './logger';
 
 interface QueueEntry {
@@ -64,8 +65,21 @@ async function processNext(channelId: string): Promise<void> {
   channel.sendTyping().catch(() => {});
 
   try {
+    // Download attachments if present
+    let attachmentRefs = '';
+    if (message.attachments.size > 0) {
+      const agentCwd = await maestro.getAgentCwd(agentId);
+      if (agentCwd) {
+        const downloaded = await downloadAttachments(message.attachments, agentCwd);
+        attachmentRefs = formatAttachmentRefs(downloaded);
+      } else {
+        await channel.send('⚠️ Could not resolve agent working directory for file downloads.');
+      }
+    }
+
     const readOnly = !!channelInfo.read_only;
-    const result = await maestro.send(agentId, message.content, sessionId, readOnly);
+    const fullMessage = [message.content, attachmentRefs].filter(Boolean).join('\n\n');
+    const result = await maestro.send(agentId, fullMessage, sessionId, readOnly);
 
     // Persist session ID from first response
     if (!sessionId && result.sessionId) {

--- a/src/services/queue.ts
+++ b/src/services/queue.ts
@@ -1,137 +1,21 @@
-import { Message, TextChannel, ThreadChannel } from 'discord.js';
 import { maestro } from './maestro';
 import { channelDb, threadDb } from '../db';
 import { splitMessage } from '../utils/splitMessage';
 import { downloadAttachments, formatAttachmentRefs } from '../utils/attachments';
 import { logger } from './logger';
+import { createQueue } from './queueFactory';
 
-interface QueueEntry {
-  message: Message;
-}
+export { createQueue } from './queueFactory';
+export type { QueueDeps } from './queueFactory';
 
-const queues = new Map<string, QueueEntry[]>();
-const processing = new Set<string>();
+const defaultQueue = createQueue({
+  maestro,
+  channelDb,
+  threadDb,
+  splitMessage,
+  downloadAttachments,
+  formatAttachmentRefs,
+  logger,
+});
 
-export function enqueue(message: Message): void {
-  const channelId = message.channel.id;
-  if (!queues.has(channelId)) queues.set(channelId, []);
-  queues.get(channelId)!.push({ message });
-
-  if (!processing.has(channelId)) {
-    // start processing asynchronously
-    void processNext(channelId);
-  }
-}
-
-async function processNext(channelId: string): Promise<void> {
-  const queue = queues.get(channelId);
-  if (!queue || queue.length === 0) {
-    processing.delete(channelId);
-    return;
-  }
-
-  processing.add(channelId);
-  const { message } = queue.shift()!;
-
-  // Resolve agent/session context — thread takes precedence over channel
-  const isThread = message.channel.isThread();
-  const threadInfo = isThread ? threadDb.get(channelId) : undefined;
-  const channelInfo = threadInfo
-    ? channelDb.get(threadInfo.channel_id)
-    : channelDb.get(channelId);
-
-  if (!channelInfo) {
-    processing.delete(channelId);
-    return;
-  }
-
-  const agentId = threadInfo ? threadInfo.agent_id : channelInfo.agent_id;
-  const sessionId = threadInfo ? (threadInfo.session_id ?? undefined) : (channelInfo.session_id ?? undefined);
-
-  const channel = message.channel as TextChannel | ThreadChannel;
-
-  // React to show we're working
-  let reaction: Awaited<ReturnType<Message['react']>> | undefined;
-  try {
-    reaction = await message.react('⏳');
-  } catch {
-    // Reaction may fail if message was deleted or bot lacks perms; continue anyway
-  }
-
-  // Show typing indicator while waiting
-  const typingInterval = setInterval(() => {
-    channel.sendTyping().catch(() => {});
-  }, 8000);
-  channel.sendTyping().catch(() => {});
-
-  try {
-    // Download attachments if present
-    let attachmentRefs = '';
-    if (message.attachments.size > 0) {
-      const agentCwd = await maestro.getAgentCwd(agentId);
-      if (agentCwd) {
-        const downloaded = await downloadAttachments(message.attachments, agentCwd);
-        attachmentRefs = formatAttachmentRefs(downloaded);
-      } else {
-        await channel.send('⚠️ Could not resolve agent working directory for file downloads.');
-      }
-    }
-
-    const readOnly = !!channelInfo.read_only;
-    const fullMessage = [message.content, attachmentRefs].filter(Boolean).join('\n\n');
-    const result = await maestro.send(agentId, fullMessage, sessionId, readOnly);
-
-    // Persist session ID from first response
-    if (!sessionId && result.sessionId) {
-      if (threadInfo) {
-        threadDb.updateSession(channelId, result.sessionId);
-      } else {
-        channelDb.updateSession(channelId, result.sessionId);
-      }
-    }
-
-    clearInterval(typingInterval);
-
-    // Remove the ⏳ reaction
-    try {
-      await reaction?.remove();
-    } catch {
-      // Ignore if already removed or no permission
-    }
-
-    // Handle agent failure (e.g. read-only mode blocked a write)
-    if (!result.success || !result.response) {
-      const reason = result.error ?? 'The agent could not complete this request.';
-      const hint = readOnly ? '\n-# The agent is in **read-only** mode and cannot modify files.' : '';
-      void logger.error('queue:agent-failure', `agent=${agentId} session=${sessionId ?? 'new'} channel=${channelId} reason=${reason}`);
-      await channel.send(`⚠️ ${reason}${hint}`);
-    } else {
-      // Post response, splitting if > 2000 chars
-      const parts = splitMessage(result.response);
-      for (const part of parts) {
-        await channel.send(part);
-      }
-    }
-
-    // Post usage footer as a subtle follow-up
-    const cost = (result.usage?.totalCostUsd ?? 0).toFixed(4);
-    const ctx = (result.usage?.contextUsagePercent ?? 0).toFixed(1);
-    const tokens = (result.usage?.inputTokens ?? 0) + (result.usage?.outputTokens ?? 0);
-    await channel.send(
-      `-# 💬 ${tokens} tokens • $${cost} • ${ctx}% context${readOnly ? ' • 📖 read-only' : ''}`
-    );
-
-  } catch (err) {
-    clearInterval(typingInterval);
-    try {
-      await reaction?.remove();
-    } catch {}
-
-    const errMsg = err instanceof Error ? err.message : String(err);
-    void logger.error('queue:send-error', `agent=${agentId} session=${sessionId ?? 'new'} channel=${channelId} error=${errMsg}`);
-    await channel.send(`❌ Failed to get response from agent:\n\`\`\`\n${errMsg}\n\`\`\``);
-  }
-
-  // Process the next item in queue
-  void processNext(channelId);
-}
+export const enqueue = defaultQueue.enqueue;

--- a/src/services/queueFactory.ts
+++ b/src/services/queueFactory.ts
@@ -90,12 +90,18 @@ export function createQueue(deps: QueueDeps) {
       // Download attachments if present
       let attachmentRefs = '';
       if (message.attachments.size > 0) {
-        const agentCwd = await deps.maestro.getAgentCwd(agentId);
-        if (agentCwd) {
-          const downloaded = await deps.downloadAttachments(message.attachments, agentCwd);
-          attachmentRefs = deps.formatAttachmentRefs(downloaded);
-        } else {
-          await channel.send('⚠️ Could not resolve agent working directory for file downloads.');
+        try {
+          const agentCwd = await deps.maestro.getAgentCwd(agentId);
+          if (agentCwd) {
+            const downloaded = await deps.downloadAttachments(message.attachments, agentCwd);
+            attachmentRefs = deps.formatAttachmentRefs(downloaded);
+          } else {
+            await channel.send('⚠️ Could not resolve agent working directory for file downloads.');
+          }
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          void deps.logger.error('queue:attachment-download', `agent=${agentId} channel=${channelId} error=${errMsg}`);
+          await channel.send('⚠️ Failed to download one or more attachments. Sending message without them.');
         }
       }
 

--- a/src/services/queueFactory.ts
+++ b/src/services/queueFactory.ts
@@ -29,7 +29,7 @@ export type QueueDeps = {
     updateSession: (threadId: string, sessionId: string) => void;
   };
   splitMessage: (text: string) => string[];
-  downloadAttachments: (attachments: Message['attachments'], agentCwd: string) => Promise<{ originalName: string; savedPath: string }[]>;
+  downloadAttachments: (attachments: Message['attachments'], agentCwd: string) => Promise<{ downloaded: { originalName: string; savedPath: string }[]; failed: string[] }>;
   formatAttachmentRefs: (files: { originalName: string; savedPath: string }[]) => string;
   logger: { error: (...args: any[]) => any };
 };
@@ -93,15 +93,18 @@ export function createQueue(deps: QueueDeps) {
         try {
           const agentCwd = await deps.maestro.getAgentCwd(agentId);
           if (agentCwd) {
-            const downloaded = await deps.downloadAttachments(message.attachments, agentCwd);
-            attachmentRefs = deps.formatAttachmentRefs(downloaded);
+            const result = await deps.downloadAttachments(message.attachments, agentCwd);
+            attachmentRefs = deps.formatAttachmentRefs(result.downloaded);
+            if (result.failed.length > 0) {
+              await channel.send(`⚠️ Failed to download: ${result.failed.join(', ')}. Sending message without those files.`);
+            }
           } else {
             await channel.send('⚠️ Could not resolve agent working directory for file downloads.');
           }
         } catch (err) {
           const errMsg = err instanceof Error ? err.message : String(err);
           void deps.logger.error('queue:attachment-download', `agent=${agentId} channel=${channelId} error=${errMsg}`);
-          await channel.send('⚠️ Failed to download one or more attachments. Sending message without them.');
+          await channel.send('⚠️ Failed to download attachments. Sending message without them.');
         }
       }
 

--- a/src/services/queueFactory.ts
+++ b/src/services/queueFactory.ts
@@ -1,0 +1,157 @@
+import { Message, TextChannel, ThreadChannel } from 'discord.js';
+
+interface QueueEntry {
+  message: Message;
+}
+
+export type QueueDeps = {
+  maestro: {
+    getAgentCwd: (agentId: string) => Promise<string | null>;
+    send: (agentId: string, message: string, sessionId?: string, readOnly?: boolean) => Promise<{
+      success: boolean;
+      response: string | null;
+      error?: string;
+      sessionId?: string;
+      usage?: {
+        inputTokens?: number;
+        outputTokens?: number;
+        totalCostUsd?: number;
+        contextUsagePercent?: number;
+      };
+    }>;
+  };
+  channelDb: {
+    get: (channelId: string) => { channel_id: string; agent_id: string; session_id?: string | null; read_only?: number | boolean } | undefined;
+    updateSession: (channelId: string, sessionId: string) => void;
+  };
+  threadDb: {
+    get: (threadId: string) => { thread_id: string; channel_id: string; agent_id: string; session_id?: string | null; owner_user_id?: string | null } | undefined;
+    updateSession: (threadId: string, sessionId: string) => void;
+  };
+  splitMessage: (text: string) => string[];
+  downloadAttachments: (attachments: Message['attachments'], agentCwd: string) => Promise<{ originalName: string; savedPath: string }[]>;
+  formatAttachmentRefs: (files: { originalName: string; savedPath: string }[]) => string;
+  logger: { error: (...args: any[]) => any };
+};
+
+export function createQueue(deps: QueueDeps) {
+  const queues = new Map<string, QueueEntry[]>();
+  const processing = new Set<string>();
+
+  function enqueue(message: Message): void {
+    const channelId = message.channel.id;
+    if (!queues.has(channelId)) queues.set(channelId, []);
+    queues.get(channelId)!.push({ message });
+
+    if (!processing.has(channelId)) {
+      void processNext(channelId);
+    }
+  }
+
+  async function processNext(channelId: string): Promise<void> {
+    const queue = queues.get(channelId);
+    if (!queue || queue.length === 0) {
+      processing.delete(channelId);
+      return;
+    }
+
+    processing.add(channelId);
+    const { message } = queue.shift()!;
+
+    const isThread = message.channel.isThread();
+    const threadInfo = isThread ? deps.threadDb.get(channelId) : undefined;
+    const channelInfo = threadInfo
+      ? deps.channelDb.get(threadInfo.channel_id)
+      : deps.channelDb.get(channelId);
+
+    if (!channelInfo) {
+      processing.delete(channelId);
+      return;
+    }
+
+    const agentId = threadInfo ? threadInfo.agent_id : channelInfo.agent_id;
+    const sessionId = threadInfo ? (threadInfo.session_id ?? undefined) : (channelInfo.session_id ?? undefined);
+
+    const channel = message.channel as TextChannel | ThreadChannel;
+
+    let reaction: Awaited<ReturnType<Message['react']>> | undefined;
+    try {
+      reaction = await message.react('⏳');
+    } catch {
+      // Reaction may fail if message was deleted or bot lacks perms; continue anyway
+    }
+
+    const typingInterval = setInterval(() => {
+      channel.sendTyping().catch(() => {});
+    }, 8000);
+    channel.sendTyping().catch(() => {});
+
+    try {
+      // Download attachments if present
+      let attachmentRefs = '';
+      if (message.attachments.size > 0) {
+        const agentCwd = await deps.maestro.getAgentCwd(agentId);
+        if (agentCwd) {
+          const downloaded = await deps.downloadAttachments(message.attachments, agentCwd);
+          attachmentRefs = deps.formatAttachmentRefs(downloaded);
+        } else {
+          await channel.send('⚠️ Could not resolve agent working directory for file downloads.');
+        }
+      }
+
+      const readOnly = !!channelInfo.read_only;
+      const fullMessage = [message.content, attachmentRefs].filter(Boolean).join('\n\n');
+      const result = await deps.maestro.send(agentId, fullMessage, sessionId, readOnly);
+
+      // Persist session ID from first response
+      if (!sessionId && result.sessionId) {
+        if (threadInfo) {
+          deps.threadDb.updateSession(channelId, result.sessionId);
+        } else {
+          deps.channelDb.updateSession(channelId, result.sessionId);
+        }
+      }
+
+      clearInterval(typingInterval);
+
+      try {
+        await reaction?.remove();
+      } catch {
+        // Ignore if already removed or no permission
+      }
+
+      if (!result.success || !result.response) {
+        const reason = result.error ?? 'The agent could not complete this request.';
+        const hint = readOnly ? '\n-# The agent is in **read-only** mode and cannot modify files.' : '';
+        void deps.logger.error('queue:agent-failure', `agent=${agentId} session=${sessionId ?? 'new'} channel=${channelId} reason=${reason}`);
+        await channel.send(`⚠️ ${reason}${hint}`);
+      } else {
+        const parts = deps.splitMessage(result.response);
+        for (const part of parts) {
+          await channel.send(part);
+        }
+      }
+
+      const cost = (result.usage?.totalCostUsd ?? 0).toFixed(4);
+      const ctx = (result.usage?.contextUsagePercent ?? 0).toFixed(1);
+      const tokens = (result.usage?.inputTokens ?? 0) + (result.usage?.outputTokens ?? 0);
+      await channel.send(
+        `-# 💬 ${tokens} tokens • $${cost} • ${ctx}% context${readOnly ? ' • 📖 read-only' : ''}`
+      );
+
+    } catch (err) {
+      clearInterval(typingInterval);
+      try {
+        await reaction?.remove();
+      } catch {}
+
+      const errMsg = err instanceof Error ? err.message : String(err);
+      void deps.logger.error('queue:send-error', `agent=${agentId} session=${sessionId ?? 'new'} channel=${channelId} error=${errMsg}`);
+      await channel.send(`❌ Failed to get response from agent:\n\`\`\`\n${errMsg}\n\`\`\``);
+    }
+
+    void processNext(channelId);
+  }
+
+  return { enqueue };
+}

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,0 +1,64 @@
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+import type { Collection, Attachment } from 'discord.js';
+
+export interface DownloadedFile {
+  originalName: string;
+  savedPath: string; // absolute path
+}
+
+export const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25 MB
+export const FILES_DIR = '.maestro/discord-files';
+
+/**
+ * Download Discord attachments to the agent's working directory.
+ * Returns an array of successfully downloaded files (never throws).
+ */
+export async function downloadAttachments(
+  attachments: Collection<string, Attachment>,
+  agentCwd: string,
+): Promise<DownloadedFile[]> {
+  const targetDir = path.join(agentCwd, FILES_DIR);
+  await mkdir(targetDir, { recursive: true });
+
+  const results: DownloadedFile[] = [];
+
+  for (const [, attachment] of attachments) {
+    if (attachment.size > MAX_FILE_SIZE) {
+      console.warn(
+        `[attachments] Skipping "${attachment.name}" (${attachment.size} bytes) — exceeds ${MAX_FILE_SIZE} byte limit`,
+      );
+      continue;
+    }
+
+    const filename = `${Date.now()}-${attachment.name}`;
+    const savedPath = path.join(targetDir, filename);
+
+    try {
+      const response = await fetch(attachment.url);
+      if (!response.ok) {
+        console.warn(
+          `[attachments] Failed to download "${attachment.name}": HTTP ${response.status}`,
+        );
+        continue;
+      }
+
+      const buffer = Buffer.from(await response.arrayBuffer());
+      await writeFile(savedPath, buffer);
+      results.push({ originalName: attachment.name, savedPath });
+    } catch (err) {
+      console.warn(`[attachments] Error downloading "${attachment.name}":`, err);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Format downloaded files as "[Attached: /path]" lines for inclusion in messages.
+ * Returns empty string if no files.
+ */
+export function formatAttachmentRefs(files: DownloadedFile[]): string {
+  if (files.length === 0) return '';
+  return files.map((f) => `[Attached: ${f.savedPath}]`).join('\n');
+}

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, rm, writeFile } from 'fs/promises';
+import { mkdir, rm, writeFile } from 'fs/promises';
 import { randomUUID } from 'crypto';
 import path from 'path';
 import type { Collection, Attachment } from 'discord.js';
@@ -44,7 +44,8 @@ export async function downloadAttachments(
       continue;
     }
 
-    const filename = `${randomUUID()}-${attachment.name}`;
+    const safeName = path.basename(attachment.name);
+    const filename = `${randomUUID()}-${safeName}`;
     const savedPath = path.join(targetDir, filename);
 
     try {
@@ -76,10 +77,9 @@ export async function downloadAttachments(
 export async function cleanupAgentFiles(agentCwd: string): Promise<void> {
   const dir = path.join(agentCwd, FILES_DIR);
   try {
-    await access(dir);
     await rm(dir, { recursive: true, force: true });
   } catch {
-    // Directory doesn't exist or can't be removed — nothing to do
+    // Removal failed (e.g., permission error) — nothing to do
   }
 }
 

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,4 +1,5 @@
 import { access, mkdir, rm, writeFile } from 'fs/promises';
+import { randomUUID } from 'crypto';
 import path from 'path';
 import type { Collection, Attachment } from 'discord.js';
 
@@ -14,24 +15,36 @@ export const FILES_DIR = '.maestro/discord-files';
  * Download Discord attachments to the agent's working directory.
  * Returns an array of successfully downloaded files (never throws).
  */
+export interface DownloadResult {
+  downloaded: DownloadedFile[];
+  failed: string[]; // original names of files that failed
+}
+
 export async function downloadAttachments(
   attachments: Collection<string, Attachment>,
   agentCwd: string,
-): Promise<DownloadedFile[]> {
+): Promise<DownloadResult> {
   const targetDir = path.join(agentCwd, FILES_DIR);
-  await mkdir(targetDir, { recursive: true });
+  try {
+    await mkdir(targetDir, { recursive: true });
+  } catch (err) {
+    console.warn(`[attachments] Failed to create directory "${targetDir}":`, err);
+    return { downloaded: [], failed: [...attachments.values()].map(a => a.name) };
+  }
 
-  const results: DownloadedFile[] = [];
+  const downloaded: DownloadedFile[] = [];
+  const failed: string[] = [];
 
   for (const [, attachment] of attachments) {
     if (attachment.size > MAX_FILE_SIZE) {
       console.warn(
         `[attachments] Skipping "${attachment.name}" (${attachment.size} bytes) — exceeds ${MAX_FILE_SIZE} byte limit`,
       );
+      failed.push(attachment.name);
       continue;
     }
 
-    const filename = `${Date.now()}-${attachment.name}`;
+    const filename = `${randomUUID()}-${attachment.name}`;
     const savedPath = path.join(targetDir, filename);
 
     try {
@@ -40,18 +53,20 @@ export async function downloadAttachments(
         console.warn(
           `[attachments] Failed to download "${attachment.name}": HTTP ${response.status}`,
         );
+        failed.push(attachment.name);
         continue;
       }
 
       const buffer = Buffer.from(await response.arrayBuffer());
       await writeFile(savedPath, buffer);
-      results.push({ originalName: attachment.name, savedPath });
+      downloaded.push({ originalName: attachment.name, savedPath });
     } catch (err) {
       console.warn(`[attachments] Error downloading "${attachment.name}":`, err);
+      failed.push(attachment.name);
     }
   }
 
-  return results;
+  return { downloaded, failed };
 }
 
 /**

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'fs/promises';
+import { access, mkdir, rm, writeFile } from 'fs/promises';
 import path from 'path';
 import type { Collection, Attachment } from 'discord.js';
 
@@ -52,6 +52,20 @@ export async function downloadAttachments(
   }
 
   return results;
+}
+
+/**
+ * Remove the `.maestro/discord-files/` directory for an agent.
+ * Silently succeeds if the directory doesn't exist.
+ */
+export async function cleanupAgentFiles(agentCwd: string): Promise<void> {
+  const dir = path.join(agentCwd, FILES_DIR);
+  try {
+    await access(dir);
+    await rm(dir, { recursive: true, force: true });
+  } catch {
+    // Directory doesn't exist or can't be removed — nothing to do
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Download Discord attachments to agent working directories and pass file path references to Maestro CLI
- Per-channel FIFO queue refactored to DI factory pattern for testability
- Cached `getAgentCwd()` avoids repeated CLI calls (60s TTL)
- Thread-aware cleanup on `/agents disconnect` — files only removed when no other channels or threads use the agent
- UUID-prefixed filenames prevent collisions under concurrent downloads
- `DownloadResult` type tracks per-file success/failure with specific error messages shown to users

## Key changes
- `src/utils/attachments.ts` — download, cleanup, format utilities with `DownloadResult` return type
- `src/services/queueFactory.ts` — DI-based queue with attachment download integration
- `src/handlers/messageCreate.ts` — `AttachmentPayload` objects for mention-triggered threads (fixes silent attachment loss)
- `src/commands/agents.ts` — thread-aware file cleanup on disconnect
- `src/db/index.ts` — `threadDb.getByAgentId()` and `threadDb.removeByChannel()` queries

## Test plan
- [x] 23/23 tests pass (attachments, queue, getAgentCwd)
- [ ] Manual: send message with attachment in agent channel → verify file downloaded and path ref sent to agent
- [ ] Manual: @mention bot with attachment → verify thread created with real attachments, file downloaded
- [ ] Manual: `/agents disconnect` on last channel → verify `.maestro/discord-files/` cleaned up
- [ ] Manual: disconnect with other channels still active → verify files preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachment support: files can be downloaded, re-uploaded/forwarded, referenced in messages, and cleaned up per agent.
  * Per-channel queuing via a new queue factory with sequential processing and retry/error handling.
  * Agent working-directory cache to reduce lookups.
  * Disconnect flow now removes thread records and conditionally cleans up agent files.

* **Bug Fixes**
  * Messages with only attachments are accepted; whitespace-only messages without attachments remain ignored.
  * Improved reporting and recovery for partial/failed attachment downloads.

* **Tests**
  * Extensive tests covering attachments, queuing, message handling, and agent CWD caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->