### PR TITLE
Fix/list sessions response

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,25 @@ Delete this file to reset all channel bindings.
 
 ## Discord bot permissions
 
-- Read Messages / View Channels
+Invite the bot with both `bot` and `applications.commands` scopes:
+
+```text
+https://discord.com/oauth2/authorize?client_id=<DISCORD_CLIENT_ID>&scope=bot+applications.commands&permissions=11280
+```
+
+This grants the following permissions:
+
+- View Channels
 - Send Messages
 - Manage Channels
-- Add Reactions
-- Read Message History
+
+Then enable **Message Content Intent** under Privileged Gateway Intents at:
+
+```text
+https://discord.com/developers/applications/<DISCORD_CLIENT_ID>/bot
+```
+
+Without this the bot will fail to connect with a "Used disallowed intents" error.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -149,14 +149,16 @@ Delete this file to reset all channel bindings.
 Invite the bot with both `bot` and `applications.commands` scopes:
 
 ```text
-https://discord.com/oauth2/authorize?client_id=<DISCORD_CLIENT_ID>&scope=bot+applications.commands&permissions=11280
+https://discord.com/oauth2/authorize?client_id=<DISCORD_CLIENT_ID>&scope=bot+applications.commands&permissions=11344
 ```
 
 This grants the following permissions:
 
+- Manage Channels
+- Add Reactions
 - View Channels
 - Send Messages
-- Manage Channels
+- Manage Messages
 
 Then enable **Message Content Intent** under Privileged Gateway Intents at:
 

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -9,6 +9,12 @@ import {
 import { maestro } from '../services/maestro';
 import { channelDb, threadDb } from '../db';
 import { cleanupAgentFiles } from '../utils/attachments';
+import { config } from '../config';
+
+const MISSING_BOT_SCOPE =
+  '❌ The bot is not a member of this server. It was likely invited with only slash-command permissions.\n\n' +
+  'Re-invite with both `bot` and `applications.commands` scopes:\n' +
+  `https://discord.com/oauth2/authorize?client_id=${config.clientId}&scope=bot+applications.commands&permissions=11280`;
 
 export const data = new SlashCommandBuilder()
   .setName('agents')
@@ -118,7 +124,7 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
   const agentInput = interaction.options.getString('agent', true);
   const guild = interaction.guild;
   if (!guild) {
-    await interaction.editReply('This command must be used in a server.');
+    await interaction.editReply(interaction.guildId ? MISSING_BOT_SCOPE : 'This command must be used in a server.');
     return;
   }
 

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -14,7 +14,7 @@ import { config } from '../config';
 const MISSING_BOT_SCOPE =
   '❌ The bot is not a member of this server. It was likely invited with only slash-command permissions.\n\n' +
   'Re-invite with both `bot` and `applications.commands` scopes:\n' +
-  `https://discord.com/oauth2/authorize?client_id=${config.clientId}&scope=bot+applications.commands&permissions=11280`;
+  `https://discord.com/oauth2/authorize?client_id=${config.clientId}&scope=bot+applications.commands&permissions=11344`;
 
 export const data = new SlashCommandBuilder()
   .setName('agents')
@@ -63,6 +63,16 @@ export async function autocomplete(interaction: AutocompleteInteraction): Promis
 }
 
 export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  if (!interaction.guild) {
+    const msg = interaction.guildId ? MISSING_BOT_SCOPE : 'This command must be used in a server.';
+    if (interaction.deferred || interaction.replied) {
+      await interaction.editReply(msg);
+    } else {
+      await interaction.reply({ content: msg, ephemeral: true });
+    }
+    return;
+  }
+
   const sub = interaction.options.getSubcommand();
 
   if (sub === 'list') {
@@ -122,11 +132,7 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
   await interaction.deferReply({ ephemeral: true });
 
   const agentInput = interaction.options.getString('agent', true);
-  const guild = interaction.guild;
-  if (!guild) {
-    await interaction.editReply(interaction.guildId ? MISSING_BOT_SCOPE : 'This command must be used in a server.');
-    return;
-  }
+  const guild = interaction.guild!;
 
   const agents = await maestro.listAgents();
   const agent = agents.find(
@@ -207,7 +213,7 @@ async function handleDisconnect(interaction: ChatInputCommandInteraction): Promi
   // Clean up downloaded files if this is the last channel for this agent
   // (also consider threads bound to other channels for the same agent)
   const agentId = channelInfo.agent_id;
-  const otherChannels = channelDb.getByAgentId(agentId).filter(
+  const otherChannels = channelDb.listByAgentId(agentId).filter(
     (c) => c.channel_id !== interaction.channelId,
   );
   const otherThreads = threadDb.getByAgentId(agentId).filter(

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -70,7 +70,7 @@ export const channelDb = {
     db.prepare('DELETE FROM agent_channels WHERE channel_id = ?').run(channelId);
   },
 
-  getByAgentId(agentId: string): AgentChannel[] {
+  listByAgentId(agentId: string): AgentChannel[] {
     return db.prepare('SELECT * FROM agent_channels WHERE agent_id = ?')
       .all(agentId) as AgentChannel[];
   },

--- a/src/services/maestro.ts
+++ b/src/services/maestro.ts
@@ -188,7 +188,8 @@ export const maestro = {
   /** List sessions for a given agent */
   async listSessions(agentId: string, limit = 25): Promise<MaestroSession[]> {
     const raw = await run(['list', 'sessions', agentId, '--json', '-l', String(limit)]);
-    return JSON.parse(raw) as MaestroSession[];
+    const parsed = JSON.parse(raw);
+    return (Array.isArray(parsed) ? parsed : parsed.sessions ?? []) as MaestroSession[];
   },
 
   /**


### PR DESCRIPTION
Fix listSessions parsing for new CLI response format

`maestro-cli list sessions` now returns `{ sessions: [...] }` instead of a bare array. This caused `maestroSessions.map is not a function` when running the /session list command.

Handles both the old array format and the new wrapper object format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Discord bot setup guide: new OAuth2 invite flow (bot + application commands) and required permissions listed; added instruction to enable Message Content Intent in the Discord Developer Portal.

* **Bug Fixes**
  * Clearer user-facing messaging when the bot lacks server permissions, including an invite link to grant required scopes.
  * Improved handling of external API/CLI responses to prevent failures from unexpected formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->