### PR TITLE
Address PR #11 review feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ node --test --experimental-test-coverage --import tsx
 | `/agents disconnect` | (Run inside an agent channel) Remove and delete the channel |
 | `/agents readonly on\|off` | Toggle read-only mode for the current agent channel |
 | `/session new` | Create a new owner-bound thread for the current agent channel |
+| `/session list` | List session threads for the current agent channel |
 
 ## How it works
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "maestro-discord": "dist/cli/maestro-discord.js"
       },
       "devDependencies": {
-        "@types/better-sqlite3": "^7.4.1",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.0.0",
         "ts-node": "^10.0.0",
         "tsx": "^3.12.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dotenv": "^16.0.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.4.1",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.0.0",
     "ts-node": "^10.0.0",
     "tsx": "^3.12.7",

--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -14,11 +14,11 @@ const createdChannels: string[] = [];
 const createdThreads: string[] = [];
 
 afterEach(() => {
-  for (const id of createdChannels) {
-    try { channelDb.remove(id); } catch { /* ignore */ }
-  }
   for (const id of createdThreads) {
     try { threadDb.remove(id); } catch { /* ignore */ }
+  }
+  for (const id of createdChannels) {
+    try { channelDb.remove(id); } catch { /* ignore */ }
   }
   createdChannels.length = 0;
   createdThreads.length = 0;
@@ -94,6 +94,7 @@ test('channelDb.setReadOnly toggles the read_only flag', () => {
 
 test('channelDb.remove deletes the channel', () => {
   const chId = uid('ch');
+  createdChannels.push(chId);
 
   channelDb.register(chId, 'guild-1', 'agent-1', 'Agent');
   assert.ok(channelDb.get(chId));
@@ -205,6 +206,7 @@ test('threadDb.listByChannel returns empty array for unknown channel', () => {
 
 test('threadDb.remove deletes the thread', () => {
   const threadId = uid('thread');
+  createdThreads.push(threadId);
 
   threadDb.register(threadId, 'channel-1', 'agent-1', 'user-1');
   assert.ok(threadDb.get(threadId));
@@ -234,6 +236,7 @@ test('threadDb.removeByChannel deletes all threads for a channel', () => {
   const channelId = uid('ch');
   const t1 = uid('thread');
   const t2 = uid('thread');
+  createdThreads.push(t1, t2);
 
   threadDb.register(t1, channelId, 'agent-1', 'user-1');
   threadDb.register(t2, channelId, 'agent-1', 'user-2');


### PR DESCRIPTION
## Summary
- Add missing `/session list` to README command table
- Update `@types/better-sqlite3` from `^7.4.1` to `^7.6.13`
- Fix test cleanup order in `db.test.ts`: delete threads before channels to respect FK constraints
- Register IDs in destructive tests for fallback cleanup on assertion failure

Addresses remaining CodeRabbit nitpicks from #11.

## Test plan
- [x] All 98 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/session list` slash command to display session threads for the current agent channel.

* **Documentation**
  * Updated command documentation with new slash command reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->