### PR TITLE
Address PR #10 review feedback

### DIFF
--- a/src/__tests__/agents-command.test.ts
+++ b/src/__tests__/agents-command.test.ts
@@ -143,9 +143,8 @@ test('agents new requires a guild', async () => {
 
   await execute(interaction);
 
-  const reply = interaction.editReply.mock.calls[0].arguments[0];
-  assert.ok(typeof reply === 'string');
-  assert.ok(reply.includes('must be used in a server'));
+  const reply = interaction.reply.mock.calls[0].arguments[0];
+  assert.ok(reply.content.includes('must be used in a server'));
 });
 
 test('agents new matches agent by prefix', async () => {

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -132,7 +132,15 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
   await interaction.deferReply({ ephemeral: true });
 
   const agentInput = interaction.options.getString('agent', true);
-  const guild = interaction.guild!;
+  const guild =
+    interaction.guild ??
+    (interaction.guildId
+      ? await interaction.client.guilds.fetch(interaction.guildId).catch(() => null)
+      : null);
+  if (!guild) {
+    await interaction.editReply(interaction.guildId ? MISSING_BOT_SCOPE : 'This command must be used in a server.');
+    return;
+  }
 
   const agents = await maestro.listAgents();
   const agent = agents.find(

--- a/src/services/maestro.ts
+++ b/src/services/maestro.ts
@@ -189,7 +189,8 @@ export const maestro = {
   async listSessions(agentId: string, limit = 25): Promise<MaestroSession[]> {
     const raw = await run(['list', 'sessions', agentId, '--json', '-l', String(limit)]);
     const parsed = JSON.parse(raw);
-    return (Array.isArray(parsed) ? parsed : parsed.sessions ?? []) as MaestroSession[];
+    const sessions = Array.isArray(parsed) ? parsed : parsed?.sessions;
+    return Array.isArray(sessions) ? sessions : [];
   },
 
   /**


### PR DESCRIPTION
## Summary
- Tighten `listSessions` parsing with explicit `Array.isArray` guard (per @chr1syy's review)
- Replace `interaction.guild!` non-null assertion in `handleNew` with guild fetch fallback
- Fix `agents new requires a guild` test to check `reply` (not `editReply`) matching the top-level guard

Addresses review feedback from #10.

## Test plan
- [x] All 98 tests pass
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)