### PR TITLE
Add Prettier/ESLint tooling and fix all lint issues

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+logs/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ node --test --experimental-test-coverage --import tsx
 
 ## Slash commands
 
-| Command | Description |
-|---|---|
-| `/health` | Verify Maestro CLI is installed and working |
-| `/agents list` | Show all available agents |
-| `/agents new <agent-id>` | Create a dedicated channel for an agent |
-| `/agents disconnect` | (Run inside an agent channel) Remove and delete the channel |
-| `/agents readonly on\|off` | Toggle read-only mode for the current agent channel |
-| `/session new` | Create a new owner-bound thread for the current agent channel |
-| `/session list` | List session threads for the current agent channel |
+| Command                    | Description                                                   |
+| -------------------------- | ------------------------------------------------------------- |
+| `/health`                  | Verify Maestro CLI is installed and working                   |
+| `/agents list`             | Show all available agents                                     |
+| `/agents new <agent-id>`   | Create a dedicated channel for an agent                       |
+| `/agents disconnect`       | (Run inside an agent channel) Remove and delete the channel   |
+| `/agents readonly on\|off` | Toggle read-only mode for the current agent channel           |
+| `/session new`             | Create a new owner-bound thread for the current agent channel |
+| `/session list`            | List session threads for the current agent channel            |
 
 ## How it works
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,14 +50,14 @@ Returns `503` with `"status":"not_ready"` if the bot is disconnected.
 
 ## Error codes
 
-| Status | Meaning |
-|--------|---------|
-| `200` | Success |
-| `400` | Missing/invalid fields or malformed JSON |
-| `404` | Agent not found in Maestro |
-| `405` | Method not allowed |
-| `413` | Request body exceeds 1 MB |
-| `415` | Wrong Content-Type (must be `application/json`) |
-| `429` | Rate limited by Discord after 3 retries |
-| `500` | Internal server error |
-| `503` | Bot not connected to Discord |
+| Status | Meaning                                         |
+| ------ | ----------------------------------------------- |
+| `200`  | Success                                         |
+| `400`  | Missing/invalid fields or malformed JSON        |
+| `404`  | Agent not found in Maestro                      |
+| `405`  | Method not allowed                              |
+| `413`  | Request body exceeds 1 MB                       |
+| `415`  | Wrong Content-Type (must be `application/json`) |
+| `429`  | Rate limited by Discord after 3 retries         |
+| `500`  | Internal server error                           |
+| `503`  | Bot not connected to Discord                    |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,16 +24,16 @@ Each thread is bound to the user who created it (via mention or `/session new`).
 
 ## Project layout
 
-| Path | Purpose |
-|------|---------|
-| `src/config.ts` | Environment variable loading |
-| `src/db/index.ts` | SQLite channel registry (`agent_channels` table) |
-| `src/services/maestro.ts` | `maestro-cli` wrapper (listAgents, listSessions, send) |
-| `src/services/queue.ts` | Per-channel FIFO message queue |
-| `src/services/logger.ts` | Logging service |
-| `src/server.ts` | Internal HTTP API server |
-| `src/commands/` | Slash command handlers |
-| `src/handlers/messageCreate.ts` | Discord message listener |
-| `src/utils/splitMessage.ts` | Splits long messages for Discord's 2000-char limit |
-| `src/deploy-commands.ts` | Registers slash commands with Discord API |
-| `bin/maestro-discord.ts` | CLI tool for agent-to-Discord messaging |
+| Path                            | Purpose                                                |
+| ------------------------------- | ------------------------------------------------------ |
+| `src/config.ts`                 | Environment variable loading                           |
+| `src/db/index.ts`               | SQLite channel registry (`agent_channels` table)       |
+| `src/services/maestro.ts`       | `maestro-cli` wrapper (listAgents, listSessions, send) |
+| `src/services/queue.ts`         | Per-channel FIFO message queue                         |
+| `src/services/logger.ts`        | Logging service                                        |
+| `src/server.ts`                 | Internal HTTP API server                               |
+| `src/commands/`                 | Slash command handlers                                 |
+| `src/handlers/messageCreate.ts` | Discord message listener                               |
+| `src/utils/splitMessage.ts`     | Splits long messages for Discord's 2000-char limit     |
+| `src/deploy-commands.ts`        | Registers slash commands with Discord API              |
+| `bin/maestro-discord.ts`        | CLI tool for agent-to-Discord messaging                |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,27 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  prettier,
+  {
+    ignores: ['dist/', 'node_modules/', 'logs/'],
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
+  {
+    files: ['src/__tests__/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,16 @@
         "maestro-discord": "dist/cli/maestro-discord.js"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.0.0",
+        "eslint": "^10.2.0",
+        "eslint-config-prettier": "^10.1.8",
+        "prettier": "^3.8.2",
         "ts-node": "^10.0.0",
         "tsx": "^3.12.7",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "typescript-eslint": "^8.58.1"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -541,6 +546,186 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -640,6 +825,27 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.35",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
@@ -656,6 +862,236 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/type-utils": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.1",
+        "@typescript-eslint/types": "^8.58.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.1",
+        "@typescript-eslint/tsconfig-utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
@@ -681,6 +1117,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -694,12 +1140,39 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -755,6 +1228,19 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -799,6 +1285,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -822,6 +1341,13 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -937,6 +1463,187 @@
         "@esbuild/win32-x64": "0.18.20"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.4",
+        "@eslint/config-helpers": "^0.5.4",
+        "@eslint/core": "^1.2.0",
+        "@eslint/plugin-kit": "^0.7.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -952,11 +1659,94 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -998,6 +1788,19 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1018,6 +1821,26 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1029,6 +1852,97 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lodash": {
       "version": "4.17.23",
@@ -1067,6 +1981,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -1082,10 +2012,24 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abi": {
@@ -1107,6 +2051,89 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/prebuild-install": {
@@ -1136,6 +2163,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -1144,6 +2197,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/rc": {
@@ -1215,6 +2278,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/simple-concat": {
@@ -1329,6 +2415,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
@@ -1415,6 +2531,19 @@
         "node": "*"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1427,6 +2556,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
+      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.1",
+        "@typescript-eslint/parser": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici": {
@@ -1444,6 +2597,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1456,6 +2619,32 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -1492,6 +2681,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,10 +23,15 @@
     "dotenv": "^16.0.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.0.0",
+    "eslint": "^10.2.0",
+    "eslint-config-prettier": "^10.1.8",
+    "prettier": "^3.8.2",
     "ts-node": "^10.0.0",
     "tsx": "^3.12.7",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "typescript-eslint": "^8.58.1"
   }
 }

--- a/src/__tests__/agents-command.test.ts
+++ b/src/__tests__/agents-command.test.ts
@@ -302,7 +302,9 @@ test('autocomplete filters agents by name', async () => {
   const responses: unknown[] = [];
   const interaction = {
     options: { getFocused: () => 'alpha' },
-    respond: mock.fn(async (items: unknown) => { responses.push(items); }),
+    respond: mock.fn(async (items: unknown) => {
+      responses.push(items);
+    }),
   } as any;
 
   await autocomplete(interaction);
@@ -316,7 +318,9 @@ test('autocomplete filters agents by name', async () => {
 
 test('autocomplete returns empty on error', async () => {
   const { maestro } = await import('../services/maestro');
-  mock.method(maestro, 'listAgents', async () => { throw new Error('CLI fail'); });
+  mock.method(maestro, 'listAgents', async () => {
+    throw new Error('CLI fail');
+  });
 
   const interaction = {
     options: { getFocused: () => '' },

--- a/src/__tests__/attachments.test.ts
+++ b/src/__tests__/attachments.test.ts
@@ -12,12 +12,13 @@ import {
   MAX_FILE_SIZE,
   FILES_DIR,
   DownloadedFile,
-  DownloadResult,
 } from '../utils/attachments';
 
 // --- Helpers ---
 
-function makeAttachment(overrides: Partial<Attachment> & { name: string; url: string; size: number }): Attachment {
+function makeAttachment(
+  overrides: Partial<Attachment> & { name: string; url: string; size: number },
+): Attachment {
   return {
     contentType: 'application/octet-stream',
     ...overrides,
@@ -37,7 +38,8 @@ function okResponse(body: string | Buffer): Response {
   return {
     ok: true,
     status: 200,
-    arrayBuffer: () => Promise.resolve(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)),
+    arrayBuffer: () =>
+      Promise.resolve(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)),
   } as unknown as Response;
 }
 
@@ -71,7 +73,9 @@ test('downloadAttachments creates .maestro/discord-files/ directory', async () =
   globalThis.fetch = () => Promise.resolve(okResponse('content'));
 
   const result = await downloadAttachments(
-    makeCollection(makeAttachment({ name: 'test.txt', url: 'https://cdn.example.com/test.txt', size: 100 })),
+    makeCollection(
+      makeAttachment({ name: 'test.txt', url: 'https://cdn.example.com/test.txt', size: 100 }),
+    ),
     tmpDir,
   );
 
@@ -85,7 +89,9 @@ test('downloadAttachments saves files with UUID-prefixed names', async () => {
   globalThis.fetch = () => Promise.resolve(okResponse('file content'));
 
   const { downloaded, failed } = await downloadAttachments(
-    makeCollection(makeAttachment({ name: 'photo.png', url: 'https://cdn.example.com/photo.png', size: 500 })),
+    makeCollection(
+      makeAttachment({ name: 'photo.png', url: 'https://cdn.example.com/photo.png', size: 500 }),
+    ),
     tmpDir,
   );
 
@@ -109,7 +115,13 @@ test('downloadAttachments skips oversized attachments and reports them as failed
   };
 
   const { downloaded, failed } = await downloadAttachments(
-    makeCollection(makeAttachment({ name: 'huge.bin', url: 'https://cdn.example.com/huge.bin', size: MAX_FILE_SIZE + 1 })),
+    makeCollection(
+      makeAttachment({
+        name: 'huge.bin',
+        url: 'https://cdn.example.com/huge.bin',
+        size: MAX_FILE_SIZE + 1,
+      }),
+    ),
     tmpDir,
   );
 
@@ -127,7 +139,11 @@ test('downloadAttachments skips failed fetches, reports them, and continues', as
 
   const { downloaded, failed } = await downloadAttachments(
     makeCollection(
-      makeAttachment({ name: 'missing.txt', url: 'https://cdn.example.com/missing.txt', size: 100 }),
+      makeAttachment({
+        name: 'missing.txt',
+        url: 'https://cdn.example.com/missing.txt',
+        size: 100,
+      }),
       makeAttachment({ name: 'ok.txt', url: 'https://cdn.example.com/ok.txt', size: 100 }),
     ),
     tmpDir,
@@ -149,7 +165,10 @@ test('formatAttachmentRefs produces correct format', () => {
     { originalName: 'b.png', savedPath: '/home/agent/files/456-b.png' },
   ];
   const result = formatAttachmentRefs(files);
-  assert.equal(result, '[Attached: /home/agent/files/123-a.txt]\n[Attached: /home/agent/files/456-b.png]');
+  assert.equal(
+    result,
+    '[Attached: /home/agent/files/123-a.txt]\n[Attached: /home/agent/files/456-b.png]',
+  );
 });
 
 test('formatAttachmentRefs returns empty string for empty array', () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -37,10 +37,7 @@ test('config.required returns values and throws on missing keys', async () => {
     assert.equal(configModule.config.guildId, 'guild-789');
     assert.deepEqual(configModule.config.allowedUserIds, ['111', '222', '333']);
 
-    assert.throws(
-      () => configModule.required('MISSING_ENV'),
-      /Missing required env var/
-    );
+    assert.throws(() => configModule.required('MISSING_ENV'), /Missing required env var/);
   } finally {
     for (const key of Object.keys(process.env)) {
       if (!(key in previousEnv)) delete process.env[key];

--- a/src/__tests__/db-migrations.test.ts
+++ b/src/__tests__/db-migrations.test.ts
@@ -19,9 +19,9 @@ test('ensureOwnerUserIdColumn adds owner_user_id and is safe to rerun', () => {
   ensureOwnerUserIdColumn(database);
   ensureOwnerUserIdColumn(database);
 
-  const columns = database
-    .prepare('PRAGMA table_info(agent_threads)')
-    .all() as Array<{ name: string }>;
+  const columns = database.prepare('PRAGMA table_info(agent_threads)').all() as Array<{
+    name: string;
+  }>;
 
   assert.ok(columns.some((column) => column.name === 'owner_user_id'));
 });

--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -15,10 +15,18 @@ const createdThreads: string[] = [];
 
 afterEach(() => {
   for (const id of createdThreads) {
-    try { threadDb.remove(id); } catch { /* ignore */ }
+    try {
+      threadDb.remove(id);
+    } catch {
+      /* ignore */
+    }
   }
   for (const id of createdChannels) {
-    try { channelDb.remove(id); } catch { /* ignore */ }
+    try {
+      channelDb.remove(id);
+    } catch {
+      /* ignore */
+    }
   }
   createdChannels.length = 0;
   createdThreads.length = 0;

--- a/src/__tests__/messageCreate.test.ts
+++ b/src/__tests__/messageCreate.test.ts
@@ -32,7 +32,11 @@ function createDeps(enqueue: (...args: any[]) => void) {
 
 test('handleMessageCreate ignores bot messages', async () => {
   let enqueued = 0;
-  const handler = createMessageCreateHandler(createDeps(() => { enqueued += 1; }));
+  const handler = createMessageCreateHandler(
+    createDeps(() => {
+      enqueued += 1;
+    }),
+  );
 
   await handler(makeMessage({ author: { bot: true } }) as any);
   assert.equal(enqueued, 0);
@@ -40,7 +44,11 @@ test('handleMessageCreate ignores bot messages', async () => {
 
 test('handleMessageCreate ignores DMs', async () => {
   let enqueued = 0;
-  const handler = createMessageCreateHandler(createDeps(() => { enqueued += 1; }));
+  const handler = createMessageCreateHandler(
+    createDeps(() => {
+      enqueued += 1;
+    }),
+  );
 
   await handler(makeMessage({ guild: null }) as any);
   assert.equal(enqueued, 0);
@@ -48,7 +56,11 @@ test('handleMessageCreate ignores DMs', async () => {
 
 test('handleMessageCreate ignores messages with no text and no attachments', async () => {
   let enqueued = 0;
-  const handler = createMessageCreateHandler(createDeps(() => { enqueued += 1; }));
+  const handler = createMessageCreateHandler(
+    createDeps(() => {
+      enqueued += 1;
+    }),
+  );
 
   await handler(makeMessage({ content: '   ', attachments: { size: 0, values: () => [] } }) as any);
   assert.equal(enqueued, 0);
@@ -56,30 +68,49 @@ test('handleMessageCreate ignores messages with no text and no attachments', asy
 
 test('handleMessageCreate allows attachment-only messages (no text)', async () => {
   let enqueued = 0;
-  const handler = createMessageCreateHandler(createDeps(() => { enqueued += 1; }));
+  const handler = createMessageCreateHandler(
+    createDeps(() => {
+      enqueued += 1;
+    }),
+  );
 
-  await handler(makeMessage({
-    content: '',
-    attachments: { size: 1, values: () => [{ url: 'https://example.com/file.png', name: 'file.png' }] },
-  }) as any);
+  await handler(
+    makeMessage({
+      content: '',
+      attachments: {
+        size: 1,
+        values: () => [{ url: 'https://example.com/file.png', name: 'file.png' }],
+      },
+    }) as any,
+  );
   assert.equal(enqueued, 1);
 });
 
 test('handleMessageCreate ignores non-thread channels', async () => {
   let enqueued = 0;
-  const handler = createMessageCreateHandler(createDeps(() => { enqueued += 1; }));
+  const handler = createMessageCreateHandler(
+    createDeps(() => {
+      enqueued += 1;
+    }),
+  );
 
   await handler(
     makeMessage({
-      channel: { id: 'channel-1', isThread: () => false, threads: { create: async () => undefined } },
-    }) as any
+      channel: {
+        id: 'channel-1',
+        isThread: () => false,
+        threads: { create: async () => undefined },
+      },
+    }) as any,
   );
   assert.equal(enqueued, 0);
 });
 
 test('handleMessageCreate ignores unregistered threads', async () => {
   let enqueued = 0;
-  const deps = createDeps(() => { enqueued += 1; });
+  const deps = createDeps(() => {
+    enqueued += 1;
+  });
   deps.threadDb.get = () => undefined;
   const handler = createMessageCreateHandler(deps);
 
@@ -89,7 +120,11 @@ test('handleMessageCreate ignores unregistered threads', async () => {
 
 test('handleMessageCreate enqueues messages for registered threads', async () => {
   let enqueued = 0;
-  const handler = createMessageCreateHandler(createDeps(() => { enqueued += 1; }));
+  const handler = createMessageCreateHandler(
+    createDeps(() => {
+      enqueued += 1;
+    }),
+  );
 
   await handler(makeMessage() as any);
   assert.equal(enqueued, 1);
@@ -97,21 +132,29 @@ test('handleMessageCreate enqueues messages for registered threads', async () =>
 
 test('handleMessageCreate enqueues messages for registered threads from the owner', async () => {
   let enqueued = 0;
-  const deps = createDeps(() => { enqueued += 1; });
+  const deps = createDeps(() => {
+    enqueued += 1;
+  });
   deps.threadDb.get = () => ({ thread_id: 'thread-1', owner_user_id: 'user-1' }) as any;
   const handler = createMessageCreateHandler(deps);
 
-  await handler(makeMessage({ author: { bot: false, id: 'user-1', username: 'owner-user' } }) as any);
+  await handler(
+    makeMessage({ author: { bot: false, id: 'user-1', username: 'owner-user' } }) as any,
+  );
   assert.equal(enqueued, 1);
 });
 
 test('handleMessageCreate silently ignores registered thread messages from non-owner', async () => {
   let enqueued = 0;
-  const deps = createDeps(() => { enqueued += 1; });
+  const deps = createDeps(() => {
+    enqueued += 1;
+  });
   deps.threadDb.get = () => ({ thread_id: 'thread-1', owner_user_id: 'owner-1' }) as any;
   const handler = createMessageCreateHandler(deps);
 
-  await handler(makeMessage({ author: { bot: false, id: 'user-2', username: 'other-user' } }) as any);
+  await handler(
+    makeMessage({ author: { bot: false, id: 'user-2', username: 'other-user' } }) as any,
+  );
   assert.equal(enqueued, 0);
 });
 
@@ -119,7 +162,9 @@ test('handleMessageCreate creates and registers a thread for bot mentions in reg
   let enqueued = 0;
   const registerCalls: unknown[][] = [];
   const sentMessages: string[] = [];
-  const deps = createDeps(() => { enqueued += 1; });
+  const deps = createDeps(() => {
+    enqueued += 1;
+  });
   deps.threadDb.register = (...args: unknown[]) => {
     registerCalls.push(args);
   };
@@ -139,13 +184,17 @@ test('handleMessageCreate creates and registers a thread for bot mentions in reg
               send: async (msg: string | { content?: string; files?: string[] }) => {
                 const text = typeof msg === 'string' ? msg : (msg.content ?? '');
                 sentMessages.push(text);
-                return { id: 'msg-forwarded', content: text, attachments: { size: 0, values: () => [] } };
+                return {
+                  id: 'msg-forwarded',
+                  content: text,
+                  attachments: { size: 0, values: () => [] },
+                };
               },
             };
           },
         },
       },
-    }) as any
+    }) as any,
   );
 
   assert.equal(enqueued, 1);
@@ -178,7 +227,7 @@ test('handleMessageCreate creates and registers a thread when mention metadata i
           }),
         },
       },
-    }) as any
+    }) as any,
   );
 
   assert.deepEqual(registerCalls, [['thread-new-2', 'channel-1', 'agent-1', 'user-42']]);
@@ -187,7 +236,10 @@ test('handleMessageCreate creates and registers a thread when mention metadata i
 test('handleMessageCreate forwards attachments as AttachmentPayload objects in mention-triggered threads', async () => {
   let enqueued = 0;
   let enqueuedMessage: any = null;
-  const deps = createDeps((msg: any) => { enqueued += 1; enqueuedMessage = msg; });
+  const deps = createDeps((msg: any) => {
+    enqueued += 1;
+    enqueuedMessage = msg;
+  });
   deps.threadDb.register = () => undefined;
 
   const handler = createMessageCreateHandler(deps as any);
@@ -196,9 +248,7 @@ test('handleMessageCreate forwards attachments as AttachmentPayload objects in m
       content: 'check this <@bot-1>',
       attachments: {
         size: 1,
-        values: () => [
-          { url: 'https://cdn.discord.com/file.png', name: 'file.png', size: 500 },
-        ],
+        values: () => [{ url: 'https://cdn.discord.com/file.png', name: 'file.png', size: 500 }],
       },
       channel: {
         id: 'channel-1',
@@ -224,7 +274,11 @@ test('handleMessageCreate forwards attachments as AttachmentPayload objects in m
                 attachments: {
                   size: 1,
                   values: () => [
-                    { url: 'https://cdn.discord.com/reupload/file.png', name: 'file.png', size: 500 },
+                    {
+                      url: 'https://cdn.discord.com/reupload/file.png',
+                      name: 'file.png',
+                      size: 500,
+                    },
                   ],
                 },
               };
@@ -232,7 +286,7 @@ test('handleMessageCreate forwards attachments as AttachmentPayload objects in m
           }),
         },
       },
-    }) as any
+    }) as any,
   );
 
   assert.equal(enqueued, 1);
@@ -259,7 +313,7 @@ test('handleMessageCreate ignores non-thread channel messages without bot mentio
           },
         },
       },
-    }) as any
+    }) as any,
   );
 
   assert.equal(created, 0);

--- a/src/__tests__/queue.test.ts
+++ b/src/__tests__/queue.test.ts
@@ -1,4 +1,4 @@
-import test, { beforeEach, mock } from 'node:test';
+import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { createQueue, QueueDeps } from '../services/queueFactory';
 
@@ -32,20 +32,29 @@ function defaultSendResult(extra: Record<string, unknown> = {}) {
 function createMockDeps(): QueueDeps & { _mocks: Record<string, ReturnType<typeof mock.fn>> } {
   const mockGetAgentCwd = mock.fn(async () => '/home/agent' as string | null);
   const mockSend = mock.fn(async () => defaultSendResult());
-  const mockDownload = mock.fn(async () => ({ downloaded: [] as { originalName: string; savedPath: string }[], failed: [] as string[] }));
+  const mockDownload = mock.fn(async () => ({
+    downloaded: [] as { originalName: string; savedPath: string }[],
+    failed: [] as string[],
+  }));
   const mockFormat = mock.fn(() => '');
   const mockLoggerError = mock.fn();
-  const mockChannelGet = mock.fn(() => ({
-    channel_id: 'channel-1',
-    agent_id: 'agent-1',
-    session_id: 'session-1',
-  }) as any);
-  const mockThreadGet = mock.fn(() => ({
-    thread_id: 'thread-1',
-    channel_id: 'channel-1',
-    agent_id: 'agent-1',
-    session_id: 'session-1',
-  }) as any);
+  const mockChannelGet = mock.fn(
+    () =>
+      ({
+        channel_id: 'channel-1',
+        agent_id: 'agent-1',
+        session_id: 'session-1',
+      }) as any,
+  );
+  const mockThreadGet = mock.fn(
+    () =>
+      ({
+        thread_id: 'thread-1',
+        channel_id: 'channel-1',
+        agent_id: 'agent-1',
+        session_id: 'session-1',
+      }) as any,
+  );
 
   return {
     maestro: { getAgentCwd: mockGetAgentCwd as any, send: mockSend as any },
@@ -175,7 +184,8 @@ test('queue handles attachment download failure gracefully', async () => {
 
   // Should log the error
   assert.equal((deps.logger.error as unknown as ReturnType<typeof mock.fn>).mock.callCount(), 1);
-  const logArgs = (deps.logger.error as unknown as ReturnType<typeof mock.fn>).mock.calls[0].arguments;
+  const logArgs = (deps.logger.error as unknown as ReturnType<typeof mock.fn>).mock.calls[0]
+    .arguments;
   assert.equal(logArgs[0], 'queue:attachment-download');
   assert.ok((logArgs[1] as string).includes('Network timeout'));
 

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -37,7 +37,15 @@ function makeClient(overrides: Record<string, unknown> = {}) {
 function makeDeps(overrides: Partial<ServerDeps> = {}): ServerDeps {
   return {
     channelDb: {
-      getByAgentId: () => ({ channel_id: 'ch-1', guild_id: 'g-1', agent_id: 'a-1', agent_name: 'Test', session_id: null, read_only: 0, created_at: 0 }),
+      getByAgentId: () => ({
+        channel_id: 'ch-1',
+        guild_id: 'g-1',
+        agent_id: 'a-1',
+        agent_name: 'Test',
+        session_id: null,
+        read_only: 0,
+        created_at: 0,
+      }),
       register: () => undefined,
     },
     maestro: { listAgents: async () => [] },
@@ -48,7 +56,10 @@ function makeDeps(overrides: Partial<ServerDeps> = {}): ServerDeps {
   };
 }
 
-function request(server: http.Server, options: { method: string; path: string; body?: object; contentType?: string }): Promise<{ status: number; body: any }> {
+function request(
+  server: http.Server,
+  options: { method: string; path: string; body?: object; contentType?: string },
+): Promise<{ status: number; body: any }> {
   return new Promise((resolve, reject) => {
     const addr = server.address() as { port: number };
     const payload = options.body ? JSON.stringify(options.body) : undefined;
@@ -57,7 +68,13 @@ function request(server: http.Server, options: { method: string; path: string; b
     if (ct) headers['Content-Type'] = ct;
     if (payload) headers['Content-Length'] = Buffer.byteLength(payload);
     const req = http.request(
-      { hostname: '127.0.0.1', port: addr.port, path: options.path, method: options.method, headers },
+      {
+        hostname: '127.0.0.1',
+        port: addr.port,
+        path: options.path,
+        method: options.method,
+        headers,
+      },
       (res) => {
         let data = '';
         res.on('data', (chunk) => (data += chunk));
@@ -148,7 +165,11 @@ test('GET /api/send returns 405', async () => {
 test('POST /api/send returns 503 when client is not ready', async () => {
   const server = await startTestServer(makeClient({ isReady: () => false }), makeDeps());
   try {
-    const res = await request(server, { method: 'POST', path: '/api/send', body: { agentId: 'a-1', message: 'hi' } });
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'hi' },
+    });
     assert.equal(res.status, 503);
     assert.equal(res.body.error, 'Bot is not connected to Discord');
   } finally {
@@ -159,7 +180,11 @@ test('POST /api/send returns 503 when client is not ready', async () => {
 test('POST /api/send returns 400 for missing fields', async () => {
   const server = await startTestServer(makeClient(), makeDeps());
   try {
-    const res = await request(server, { method: 'POST', path: '/api/send', body: { agentId: 'a-1' } });
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1' },
+    });
     assert.equal(res.status, 400);
     assert.match(res.body.error, /required/);
   } finally {
@@ -173,13 +198,19 @@ test('POST /api/send returns 200 on success', async () => {
     channels: {
       fetch: async () => ({
         isSendable: () => true,
-        send: async (msg: string) => { sentMessages.push(msg); },
+        send: async (msg: string) => {
+          sentMessages.push(msg);
+        },
       }),
     },
   });
   const server = await startTestServer(client, makeDeps());
   try {
-    const res = await request(server, { method: 'POST', path: '/api/send', body: { agentId: 'a-1', message: 'hello' } });
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'hello' },
+    });
     assert.equal(res.status, 200);
     assert.equal(res.body.success, true);
     assert.equal(res.body.channelId, 'ch-1');
@@ -195,14 +226,20 @@ test('POST /api/send prepends mention when mention=true and mentionUserId is set
     channels: {
       fetch: async () => ({
         isSendable: () => true,
-        send: async (msg: string) => { sentMessages.push(msg); },
+        send: async (msg: string) => {
+          sentMessages.push(msg);
+        },
       }),
     },
   });
   const deps = makeDeps({ config: { guildId: 'g-1', apiPort: 0, mentionUserId: '999' } });
   const server = await startTestServer(client, deps);
   try {
-    const res = await request(server, { method: 'POST', path: '/api/send', body: { agentId: 'a-1', message: 'done', mention: true } });
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'done', mention: true },
+    });
     assert.equal(res.status, 200);
     assert.deepEqual(sentMessages, ['<@999> done']);
   } finally {
@@ -216,13 +253,19 @@ test('POST /api/send does not mention when mentionUserId is empty', async () => 
     channels: {
       fetch: async () => ({
         isSendable: () => true,
-        send: async (msg: string) => { sentMessages.push(msg); },
+        send: async (msg: string) => {
+          sentMessages.push(msg);
+        },
       }),
     },
   });
   const server = await startTestServer(client, makeDeps());
   try {
-    const res = await request(server, { method: 'POST', path: '/api/send', body: { agentId: 'a-1', message: 'done', mention: true } });
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'done', mention: true },
+    });
     assert.equal(res.status, 200);
     assert.deepEqual(sentMessages, ['done']);
   } finally {
@@ -240,7 +283,11 @@ test('POST /api/send returns 404 for unknown agent', async () => {
   });
   const server = await startTestServer(makeClient(), deps);
   try {
-    const res = await request(server, { method: 'POST', path: '/api/send', body: { agentId: 'missing', message: 'hi' } });
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'missing', message: 'hi' },
+    });
     assert.equal(res.status, 404);
     assert.match(res.body.error, /Agent not found/);
   } finally {
@@ -254,7 +301,13 @@ test('POST /api/send returns 415 for wrong content type', async () => {
     const addr = server.address() as { port: number };
     const res = await new Promise<{ status: number; body: any }>((resolve, reject) => {
       const req = http.request(
-        { hostname: '127.0.0.1', port: addr.port, path: '/api/send', method: 'POST', headers: { 'Content-Type': 'text/plain' } },
+        {
+          hostname: '127.0.0.1',
+          port: addr.port,
+          path: '/api/send',
+          method: 'POST',
+          headers: { 'Content-Type': 'text/plain' },
+        },
         (res) => {
           let data = '';
           res.on('data', (chunk) => (data += chunk));
@@ -275,7 +328,12 @@ test('POST /api/send returns 415 for wrong content type', async () => {
 
 test('parseBody rejects invalid JSON', async () => {
   const { Readable } = await import('node:stream');
-  const req = new Readable({ read() { this.push('not json'); this.push(null); } }) as any;
+  const req = new Readable({
+    read() {
+      this.push('not json');
+      this.push(null);
+    },
+  }) as any;
   req.headers = {};
   req.destroy = () => {};
   await assert.rejects(mod.parseBody!(req), /Invalid JSON/);

--- a/src/__tests__/session-command.test.ts
+++ b/src/__tests__/session-command.test.ts
@@ -141,12 +141,29 @@ test('session list shows threads with session info', async () => {
     agent_name: 'TestBot',
   }));
   mock.method(threadDb, 'listByChannel', () => [
-    { thread_id: 'thread-1', channel_id: 'ch-1', agent_id: 'agent-1', session_id: 'sess-abc123', owner_user_id: 'user-1', created_at: 1000 },
+    {
+      thread_id: 'thread-1',
+      channel_id: 'ch-1',
+      agent_id: 'agent-1',
+      session_id: 'sess-abc123',
+      owner_user_id: 'user-1',
+      created_at: 1000,
+    },
   ]);
 
   const { maestro } = await import('../services/maestro');
   mock.method(maestro, 'listSessions', async () => [
-    { sessionId: 'sess-abc123', sessionName: 'Test', modifiedAt: '2026-04-01', messageCount: 5, costUsd: 0.05, inputTokens: 1000, outputTokens: 500, durationSeconds: 60, starred: false },
+    {
+      sessionId: 'sess-abc123',
+      sessionName: 'Test',
+      modifiedAt: '2026-04-01',
+      messageCount: 5,
+      costUsd: 0.05,
+      inputTokens: 1000,
+      outputTokens: 500,
+      durationSeconds: 60,
+      starred: false,
+    },
   ]);
 
   const interaction = makeInteraction({
@@ -194,11 +211,20 @@ test('session list handles maestro session fetch failure gracefully', async () =
     agent_name: 'TestBot',
   }));
   mock.method(threadDb, 'listByChannel', () => [
-    { thread_id: 'thread-1', channel_id: 'ch-1', agent_id: 'agent-1', session_id: 'sess-1', owner_user_id: 'user-1', created_at: 1000 },
+    {
+      thread_id: 'thread-1',
+      channel_id: 'ch-1',
+      agent_id: 'agent-1',
+      session_id: 'sess-1',
+      owner_user_id: 'user-1',
+      created_at: 1000,
+    },
   ]);
 
   const { maestro } = await import('../services/maestro');
-  mock.method(maestro, 'listSessions', async () => { throw new Error('CLI error'); });
+  mock.method(maestro, 'listSessions', async () => {
+    throw new Error('CLI error');
+  });
 
   const interaction = makeInteraction({
     options: { getSubcommand: () => 'list' },

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -29,10 +29,12 @@ export const data = new SlashCommandBuilder()
           .setName('agent')
           .setDescription('Select an agent')
           .setRequired(true)
-          .setAutocomplete(true)
-      )
+          .setAutocomplete(true),
+      ),
   )
-  .addSubcommand((sub) => sub.setName('disconnect').setDescription('Remove this agent channel (deletes the channel)'))
+  .addSubcommand((sub) =>
+    sub.setName('disconnect').setDescription('Remove this agent channel (deletes the channel)'),
+  )
   .addSubcommand((sub) =>
     sub
       .setName('readonly')
@@ -42,8 +44,8 @@ export const data = new SlashCommandBuilder()
           .setName('mode')
           .setDescription('Turn read-only on or off')
           .setRequired(true)
-          .addChoices({ name: 'on', value: 'on' }, { name: 'off', value: 'off' })
-      )
+          .addChoices({ name: 'on', value: 'on' }, { name: 'off', value: 'off' }),
+      ),
   );
 
 export async function autocomplete(interaction: AutocompleteInteraction): Promise<void> {
@@ -52,10 +54,10 @@ export async function autocomplete(interaction: AutocompleteInteraction): Promis
   try {
     const agents = await maestro.listAgents();
     const filtered = agents.filter(
-      (a) => a.name.toLowerCase().includes(focused) || a.id.toLowerCase().includes(focused)
+      (a) => a.name.toLowerCase().includes(focused) || a.id.toLowerCase().includes(focused),
     );
     await interaction.respond(
-      filtered.slice(0, 25).map((a) => ({ name: `${a.name} (${a.toolType})`, value: a.id }))
+      filtered.slice(0, 25).map((a) => ({ name: `${a.name} (${a.toolType})`, value: a.id })),
     );
   } catch {
     await interaction.respond([]);
@@ -96,9 +98,7 @@ async function handleList(interaction: ChatInputCommandInteraction): Promise<voi
     return;
   }
 
-  const lines = agents.map(
-    (a) => `**${a.name}** · \`${a.id}\` · ${a.toolType}`
-  );
+  const lines = agents.map((a) => `**${a.name}** · \`${a.id}\` · ${a.toolType}`);
 
   // Build a single embed; Discord limits description to 4096 chars and
   // total embed content to 6000 chars per message.  With compact one-line
@@ -138,25 +138,27 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
       ? await interaction.client.guilds.fetch(interaction.guildId).catch(() => null)
       : null);
   if (!guild) {
-    await interaction.editReply(interaction.guildId ? MISSING_BOT_SCOPE : 'This command must be used in a server.');
+    await interaction.editReply(
+      interaction.guildId ? MISSING_BOT_SCOPE : 'This command must be used in a server.',
+    );
     return;
   }
 
   const agents = await maestro.listAgents();
   const agent = agents.find(
-    (a) => a.id === agentInput || a.id.startsWith(agentInput) || a.name === agentInput
+    (a) => a.id === agentInput || a.id.startsWith(agentInput) || a.name === agentInput,
   );
 
   if (!agent) {
     await interaction.editReply(
-      `❌ No agent found matching \`${agentInput}\`. Use \`/agents list\` to see available agents.`
+      `❌ No agent found matching \`${agentInput}\`. Use \`/agents list\` to see available agents.`,
     );
     return;
   }
 
   // Find or create "Maestro Agents" category
   let category = guild.channels.cache.find(
-    (c) => c.type === ChannelType.GuildCategory && c.name === 'Maestro Agents'
+    (c) => c.type === ChannelType.GuildCategory && c.name === 'Maestro Agents',
   );
   if (!category) {
     category = await guild.channels.create({
@@ -177,13 +179,13 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
 
   await interaction.editReply(
     `✅ Created <#${channel.id}> for agent **${agent.name}**.\n` +
-      `Type your messages there to chat with the agent.`
+      `Type your messages there to chat with the agent.`,
   );
 
   await channel.send(
     `**${agent.name}** is ready.\n` +
       `Type any message here and it will be sent to this agent.\n` +
-      `-# Agent: \`${agent.id}\` • ${agent.toolType} • \`${agent.cwd}\``
+      `-# Agent: \`${agent.id}\` • ${agent.toolType} • \`${agent.cwd}\``,
   );
 }
 
@@ -203,7 +205,7 @@ async function handleReadonly(interaction: ChatInputCommandInteraction): Promise
     .setDescription(
       readOnly
         ? `📖 **${channelInfo.agent_name}** is now in **read-only** mode. The agent cannot modify files.`
-        : `✏️ **${channelInfo.agent_name}** is back to **read-write** mode.`
+        : `✏️ **${channelInfo.agent_name}** is back to **read-write** mode.`,
     );
 
   await interaction.reply({ embeds: [embed] });
@@ -216,17 +218,20 @@ async function handleDisconnect(interaction: ChatInputCommandInteraction): Promi
     return;
   }
 
-  await interaction.reply({ content: `Disconnecting **${channelInfo.agent_name}**...`, ephemeral: true });
+  await interaction.reply({
+    content: `Disconnecting **${channelInfo.agent_name}**...`,
+    ephemeral: true,
+  });
 
   // Clean up downloaded files if this is the last channel for this agent
   // (also consider threads bound to other channels for the same agent)
   const agentId = channelInfo.agent_id;
-  const otherChannels = channelDb.listByAgentId(agentId).filter(
-    (c) => c.channel_id !== interaction.channelId,
-  );
-  const otherThreads = threadDb.getByAgentId(agentId).filter(
-    (t) => t.channel_id !== interaction.channelId,
-  );
+  const otherChannels = channelDb
+    .listByAgentId(agentId)
+    .filter((c) => c.channel_id !== interaction.channelId);
+  const otherThreads = threadDb
+    .getByAgentId(agentId)
+    .filter((t) => t.channel_id !== interaction.channelId);
 
   if (otherChannels.length === 0 && otherThreads.length === 0) {
     try {
@@ -239,7 +244,9 @@ async function handleDisconnect(interaction: ChatInputCommandInteraction): Promi
       console.warn(`[disconnect] Failed to clean up files for agent ${agentId}:`, err);
     }
   } else {
-    console.log(`[disconnect] Skipping file cleanup for agent ${agentId} — ${otherChannels.length} other channel(s) and ${otherThreads.length} other thread(s) still active`);
+    console.log(
+      `[disconnect] Skipping file cleanup for agent ${agentId} — ${otherChannels.length} other channel(s) and ${otherThreads.length} other thread(s) still active`,
+    );
   }
 
   // Remove channel and its threads from DB

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -12,26 +12,27 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
   if (!installed) {
     await interaction.editReply(
       '❌ `maestro-cli` not found. Please install Maestro and ensure it is in your PATH.\n' +
-      'Visit https://maestro.sh for installation instructions.'
+        'Visit https://maestro.sh for installation instructions.',
     );
     return;
   }
 
-  let agentCount = 0;
+  let agentCount: number;
   try {
-    const agents = await maestro.listAgents();
-    agentCount = agents.length;
+    agentCount = (await maestro.listAgents()).length;
   } catch (err) {
     await interaction.editReply(
       '⚠️ `maestro-cli` is installed, but failed to list agents. ' +
-      'Make sure Maestro is running.\n```' + String(err) + '```'
+        'Make sure Maestro is running.\n```' +
+        String(err) +
+        '```',
     );
     return;
   }
 
   await interaction.editReply(
     `✅ Maestro CLI is healthy.\n` +
-    `Found **${agentCount}** agent${agentCount !== 1 ? 's' : ''}. ` +
-    `Use \`/agents\` to see them.`
+      `Found **${agentCount}** agent${agentCount !== 1 ? 's' : ''}. ` +
+      `Use \`/agents\` to see them.`,
   );
 }

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -16,11 +16,11 @@ export const data = new SlashCommandBuilder()
       .setName('new')
       .setDescription('Create a new session thread for this agent')
       .addStringOption((opt) =>
-        opt.setName('name').setDescription('Name for this session thread').setRequired(false)
-      )
+        opt.setName('name').setDescription('Name for this session thread').setRequired(false),
+      ),
   )
   .addSubcommand((sub) =>
-    sub.setName('list').setDescription('List all session threads for this agent')
+    sub.setName('list').setDescription('List all session threads for this agent'),
   );
 
 export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -73,11 +73,11 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
   threadDb.register(thread.id, interaction.channelId, channelInfo.agent_id, interaction.user.id);
 
   await thread.send(
-    `🤖 **${channelInfo.agent_name}** — ready for a new session.\nType your first message to begin. This thread is linked to a dedicated Maestro session.\nOnly <@${interaction.user.id}> can interact with the agent in this thread.`
+    `🤖 **${channelInfo.agent_name}** — ready for a new session.\nType your first message to begin. This thread is linked to a dedicated Maestro session.\nOnly <@${interaction.user.id}> can interact with the agent in this thread.`,
   );
 
   await interaction.editReply(
-    `🧵 Session thread created: <#${thread.id}>\nChat with **${channelInfo.agent_name}** inside that thread.`
+    `🧵 Session thread created: <#${thread.id}>\nChat with **${channelInfo.agent_name}** inside that thread.`,
   );
 }
 
@@ -102,15 +102,10 @@ async function handleList(interaction: ChatInputCommandInteraction): Promise<voi
     // fall through with empty list
   }
 
-  const sessionMap = new Map<string, MaestroSession>(
-    maestroSessions.map((s) => [s.sessionId, s])
-  );
+  const sessionMap = new Map<string, MaestroSession>(maestroSessions.map((s) => [s.sessionId, s]));
 
   const lines = dbThreads.map((t) => {
     const maestroInfo = sessionMap.get(t.session_id ?? '');
-    const threadName =
-      (interaction.guild?.channels.cache.get(t.thread_id) as { name?: string } | undefined)
-        ?.name ?? 'Unknown thread';
     const shortId = t.session_id ? t.session_id.slice(0, 8) : 'no session yet';
     const stats = maestroInfo
       ? `${maestroInfo.messageCount} msgs · $${maestroInfo.costUsd.toFixed(4)} · ${new Date(maestroInfo.modifiedAt).toLocaleDateString()}`

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -40,30 +40,38 @@ export interface AgentChannel {
 
 export const channelDb = {
   register(channelId: string, guildId: string, agentId: string, agentName: string): void {
-    db.prepare(`
+    db.prepare(
+      `
       INSERT INTO agent_channels (channel_id, guild_id, agent_id, agent_name)
       VALUES (?, ?, ?, ?)
-    `).run(channelId, guildId, agentId, agentName);
+    `,
+    ).run(channelId, guildId, agentId, agentName);
   },
 
   get(channelId: string): AgentChannel | undefined {
-    return db.prepare('SELECT * FROM agent_channels WHERE channel_id = ?')
-      .get(channelId) as AgentChannel | undefined;
+    return db.prepare('SELECT * FROM agent_channels WHERE channel_id = ?').get(channelId) as
+      | AgentChannel
+      | undefined;
   },
 
   getByAgentId(agentId: string): AgentChannel | undefined {
-    return db.prepare('SELECT * FROM agent_channels WHERE agent_id = ?')
-      .get(agentId) as AgentChannel | undefined;
+    return db.prepare('SELECT * FROM agent_channels WHERE agent_id = ?').get(agentId) as
+      | AgentChannel
+      | undefined;
   },
 
   updateSession(channelId: string, sessionId: string | null): void {
-    db.prepare('UPDATE agent_channels SET session_id = ? WHERE channel_id = ?')
-      .run(sessionId, channelId);
+    db.prepare('UPDATE agent_channels SET session_id = ? WHERE channel_id = ?').run(
+      sessionId,
+      channelId,
+    );
   },
 
   setReadOnly(channelId: string, readOnly: boolean): void {
-    db.prepare('UPDATE agent_channels SET read_only = ? WHERE channel_id = ?')
-      .run(readOnly ? 1 : 0, channelId);
+    db.prepare('UPDATE agent_channels SET read_only = ? WHERE channel_id = ?').run(
+      readOnly ? 1 : 0,
+      channelId,
+    );
   },
 
   remove(channelId: string): void {
@@ -71,20 +79,22 @@ export const channelDb = {
   },
 
   listByAgentId(agentId: string): AgentChannel[] {
-    return db.prepare('SELECT * FROM agent_channels WHERE agent_id = ?')
+    return db
+      .prepare('SELECT * FROM agent_channels WHERE agent_id = ?')
       .all(agentId) as AgentChannel[];
   },
 
   listByGuild(guildId: string): AgentChannel[] {
-    return db.prepare('SELECT * FROM agent_channels WHERE guild_id = ?')
+    return db
+      .prepare('SELECT * FROM agent_channels WHERE guild_id = ?')
       .all(guildId) as AgentChannel[];
   },
 };
 
 export interface AgentThread {
-  thread_id:  string;
+  thread_id: string;
   channel_id: string;
-  agent_id:   string;
+  agent_id: string;
   owner_user_id: string | null;
   session_id: string | null;
   created_at: number;
@@ -92,24 +102,30 @@ export interface AgentThread {
 
 export const threadDb = {
   register(threadId: string, channelId: string, agentId: string, ownerUserId: string): void {
-    db.prepare(`
+    db.prepare(
+      `
       INSERT INTO agent_threads (thread_id, channel_id, agent_id, owner_user_id)
       VALUES (?, ?, ?, ?)
-    `).run(threadId, channelId, agentId, ownerUserId);
+    `,
+    ).run(threadId, channelId, agentId, ownerUserId);
   },
 
   get(threadId: string): AgentThread | undefined {
-    return db.prepare('SELECT * FROM agent_threads WHERE thread_id = ?')
-      .get(threadId) as AgentThread | undefined;
+    return db.prepare('SELECT * FROM agent_threads WHERE thread_id = ?').get(threadId) as
+      | AgentThread
+      | undefined;
   },
 
   updateSession(threadId: string, sessionId: string | null): void {
-    db.prepare('UPDATE agent_threads SET session_id = ? WHERE thread_id = ?')
-      .run(sessionId, threadId);
+    db.prepare('UPDATE agent_threads SET session_id = ? WHERE thread_id = ?').run(
+      sessionId,
+      threadId,
+    );
   },
 
   listByChannel(channelId: string): AgentThread[] {
-    return db.prepare('SELECT * FROM agent_threads WHERE channel_id = ? ORDER BY created_at DESC')
+    return db
+      .prepare('SELECT * FROM agent_threads WHERE channel_id = ? ORDER BY created_at DESC')
       .all(channelId) as AgentThread[];
   },
 
@@ -118,7 +134,8 @@ export const threadDb = {
   },
 
   getByAgentId(agentId: string): AgentThread[] {
-    return db.prepare('SELECT * FROM agent_threads WHERE agent_id = ?')
+    return db
+      .prepare('SELECT * FROM agent_threads WHERE agent_id = ?')
       .all(agentId) as AgentThread[];
   },
 

--- a/src/handlers/messageCreate.ts
+++ b/src/handlers/messageCreate.ts
@@ -44,11 +44,14 @@ export function createMessageCreateHandler(deps: MessageCreateDeps) {
         message.content.includes(`<@${botUserId}>`) ||
         message.content.includes(`<@!${botUserId}>`) ||
         (!!botRoleId && message.content.includes(`<@&${botRoleId}>`));
-      console.debug(`[mention] botUserId=${botUserId} botRoleId=${botRoleId} user=${mentionedByUser} role=${mentionedByRole} content=${mentionedByContent} raw=${JSON.stringify(message.content)}`);
+      console.debug(
+        `[mention] botUserId=${botUserId} botRoleId=${botRoleId} user=${mentionedByUser} role=${mentionedByRole} content=${mentionedByContent} raw=${JSON.stringify(message.content)}`,
+      );
       if (!mentionedByUser && !mentionedByRole && !mentionedByContent) return;
 
       try {
-        const authorName = message.member?.displayName ?? message.author.username ?? message.author.id;
+        const authorName =
+          message.member?.displayName ?? message.author.username ?? message.author.id;
         const safeAuthorName = authorName.replace(/[^a-zA-Z0-9_-]/g, '-').slice(0, 48);
         const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
         const threadName = `${safeAuthorName || 'user'}-${timestamp}`.slice(0, 100);
@@ -59,7 +62,12 @@ export function createMessageCreateHandler(deps: MessageCreateDeps) {
           reason: `Mention-triggered thread for ${message.author.id}`,
         });
 
-        deps.threadDb.register(thread.id, message.channel.id, channelInfo.agent_id, message.author.id);
+        deps.threadDb.register(
+          thread.id,
+          message.channel.id,
+          channelInfo.agent_id,
+          message.author.id,
+        );
         await thread.send(`This thread is bound to <@${message.author.id}>.`);
 
         // Forward the triggering message to the agent via the new thread
@@ -71,7 +79,7 @@ export function createMessageCreateHandler(deps: MessageCreateDeps) {
         if (cleanContent || message.attachments.size > 0) {
           // Re-upload attachments so the thread message has real discord.js
           // Attachment objects (sending bare URLs produces attachments.size===0).
-          const files = [...message.attachments.values()].map(a => ({
+          const files = [...message.attachments.values()].map((a) => ({
             attachment: a.url,
             name: a.name,
           }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,15 +30,16 @@ client.once('ready', (c) => {
 
 client.on('interactionCreate', async (interaction: Interaction) => {
   const isUnauthorized =
-    config.allowedUserIds.length > 0 &&
-    !config.allowedUserIds.includes(interaction.user.id);
+    config.allowedUserIds.length > 0 && !config.allowedUserIds.includes(interaction.user.id);
 
   if (interaction.isAutocomplete()) {
     if (isUnauthorized) {
       await interaction.respond([]);
       return;
     }
-    const cmd = commands.get(interaction.commandName) as { autocomplete?: (i: typeof interaction) => Promise<void> };
+    const cmd = commands.get(interaction.commandName) as {
+      autocomplete?: (i: typeof interaction) => Promise<void>;
+    };
     if (cmd?.autocomplete) {
       try {
         await cmd.autocomplete(interaction);

--- a/src/server.ts
+++ b/src/server.ts
@@ -86,7 +86,7 @@ export function createServerHandler(client: Client, deps: ServerDeps) {
 
       // Find or create "Maestro Agents" category (deduplicated across concurrent requests)
       let category = guild.channels.cache.find(
-        (c) => c.type === ChannelType.GuildCategory && c.name === 'Maestro Agents'
+        (c) => c.type === ChannelType.GuildCategory && c.name === 'Maestro Agents',
       );
       if (!category) {
         if (!pendingCategory) {
@@ -103,12 +103,12 @@ export function createServerHandler(client: Client, deps: ServerDeps) {
       }
 
       const channelName = `agent-${agent.name.toLowerCase().replace(/[^a-z0-9-]/g, '-')}`;
-      const channel = (await guild.channels.create({
+      const channel = await guild.channels.create({
         name: channelName,
         type: ChannelType.GuildText,
         parent: category!.id,
         topic: `Maestro agent: ${agent.name} (${agent.id}) | ${agent.toolType} | ${agent.cwd}`,
-      }));
+      });
 
       deps.channelDb.register(channel.id, guild.id, agent.id, agent.name);
 
@@ -159,7 +159,10 @@ export function createServerHandler(client: Client, deps: ServerDeps) {
       typeof body.message !== 'string' ||
       body.message.trim() === ''
     ) {
-      sendJson(res, 400, { success: false, error: 'agentId and message are required non-empty strings' });
+      sendJson(res, 400, {
+        success: false,
+        error: 'agentId and message are required non-empty strings',
+      });
       return;
     }
 

--- a/src/services/maestro.ts
+++ b/src/services/maestro.ts
@@ -64,7 +64,14 @@ export interface MaestroPlaybookDetail extends MaestroPlaybook {
 }
 
 export interface PlaybookEvent {
-  type: 'start' | 'document_start' | 'task_start' | 'task_complete' | 'document_complete' | 'loop_complete' | 'complete';
+  type:
+    | 'start'
+    | 'document_start'
+    | 'task_start'
+    | 'task_complete'
+    | 'document_complete'
+    | 'loop_complete'
+    | 'complete';
   timestamp: number;
   success?: boolean;
   summary?: string;
@@ -92,7 +99,13 @@ async function run(args: string[], opts: RunOptions = {}): Promise<string> {
     })) as { stdout: string; stderr: string };
     return stdout.trim();
   } catch (err: unknown) {
-    const e = err as { message?: string; stderr?: string; stdout?: string; code?: string | number; killed?: boolean };
+    const e = err as {
+      message?: string;
+      stderr?: string;
+      stdout?: string;
+      code?: string | number;
+      killed?: boolean;
+    };
     const parts: string[] = [];
     if (e.killed) parts.push('process killed (timeout?)');
     if (e.code) parts.push(`exit code: ${e.code}`);
@@ -101,7 +114,7 @@ async function run(args: string[], opts: RunOptions = {}): Promise<string> {
     if (parts.length === 0) parts.push(e.message || String(err));
     const detail = parts.join(' | ');
     console.error(`[maestro-cli ${args[0]}] ${detail}`);
-    throw new Error(`maestro-cli ${args[0]} failed: ${detail}`);
+    throw new Error(`maestro-cli ${args[0]} failed: ${detail}`, { cause: err });
   }
 }
 
@@ -179,7 +192,7 @@ export const maestro = {
     const now = Date.now();
     if (!agentCwdCache || now - agentCwdCacheTime > AGENT_CWD_CACHE_TTL) {
       const agents = await this.listAgents();
-      agentCwdCache = new Map(agents.map(a => [a.id, a.cwd]));
+      agentCwdCache = new Map(agents.map((a) => [a.id, a.cwd]));
       agentCwdCacheTime = now;
     }
     return agentCwdCache.get(agentId) ?? null;
@@ -198,7 +211,12 @@ export const maestro = {
    * If sessionId is provided, resumes that session; otherwise starts a new one.
    * Returns the full structured response.
    */
-  async send(agentId: string, message: string, sessionId?: string, readOnly?: boolean): Promise<SendResult> {
+  async send(
+    agentId: string,
+    message: string,
+    sessionId?: string,
+    readOnly?: boolean,
+  ): Promise<SendResult> {
     const args = ['send', agentId, message];
     if (sessionId) args.push('-s', sessionId);
     if (readOnly) args.push('-r');
@@ -213,7 +231,9 @@ export const maestro = {
         try {
           const parsed = JSON.parse(stdoutMatch[1]) as SendResult;
           if (parsed.agentId && parsed.usage) return parsed;
-        } catch { /* not valid JSON, fall through */ }
+        } catch {
+          /* not valid JSON, fall through */
+        }
       }
       throw err;
     }
@@ -239,7 +259,10 @@ export const maestro = {
       timeoutMs: 30 * 60 * 1000,
       maxBuffer: 100 * 1024 * 1024, // 100MB for long JSONL output
     });
-    const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    const lines = raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
 
     for (let i = lines.length - 1; i >= 0; i -= 1) {
       const line = lines[i];

--- a/src/services/queueFactory.ts
+++ b/src/services/queueFactory.ts
@@ -7,7 +7,12 @@ interface QueueEntry {
 export type QueueDeps = {
   maestro: {
     getAgentCwd: (agentId: string) => Promise<string | null>;
-    send: (agentId: string, message: string, sessionId?: string, readOnly?: boolean) => Promise<{
+    send: (
+      agentId: string,
+      message: string,
+      sessionId?: string,
+      readOnly?: boolean,
+    ) => Promise<{
       success: boolean;
       response: string | null;
       error?: string;
@@ -21,16 +26,35 @@ export type QueueDeps = {
     }>;
   };
   channelDb: {
-    get: (channelId: string) => { channel_id: string; agent_id: string; session_id?: string | null; read_only?: number | boolean } | undefined;
+    get: (channelId: string) =>
+      | {
+          channel_id: string;
+          agent_id: string;
+          session_id?: string | null;
+          read_only?: number | boolean;
+        }
+      | undefined;
     updateSession: (channelId: string, sessionId: string) => void;
   };
   threadDb: {
-    get: (threadId: string) => { thread_id: string; channel_id: string; agent_id: string; session_id?: string | null; owner_user_id?: string | null } | undefined;
+    get: (threadId: string) =>
+      | {
+          thread_id: string;
+          channel_id: string;
+          agent_id: string;
+          session_id?: string | null;
+          owner_user_id?: string | null;
+        }
+      | undefined;
     updateSession: (threadId: string, sessionId: string) => void;
   };
   splitMessage: (text: string) => string[];
-  downloadAttachments: (attachments: Message['attachments'], agentCwd: string) => Promise<{ downloaded: { originalName: string; savedPath: string }[]; failed: string[] }>;
+  downloadAttachments: (
+    attachments: Message['attachments'],
+    agentCwd: string,
+  ) => Promise<{ downloaded: { originalName: string; savedPath: string }[]; failed: string[] }>;
   formatAttachmentRefs: (files: { originalName: string; savedPath: string }[]) => string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   logger: { error: (...args: any[]) => any };
 };
 
@@ -70,7 +94,9 @@ export function createQueue(deps: QueueDeps) {
     }
 
     const agentId = threadInfo ? threadInfo.agent_id : channelInfo.agent_id;
-    const sessionId = threadInfo ? (threadInfo.session_id ?? undefined) : (channelInfo.session_id ?? undefined);
+    const sessionId = threadInfo
+      ? (threadInfo.session_id ?? undefined)
+      : (channelInfo.session_id ?? undefined);
 
     const channel = message.channel as TextChannel | ThreadChannel;
 
@@ -96,14 +122,19 @@ export function createQueue(deps: QueueDeps) {
             const result = await deps.downloadAttachments(message.attachments, agentCwd);
             attachmentRefs = deps.formatAttachmentRefs(result.downloaded);
             if (result.failed.length > 0) {
-              await channel.send(`⚠️ Failed to download: ${result.failed.join(', ')}. Sending message without those files.`);
+              await channel.send(
+                `⚠️ Failed to download: ${result.failed.join(', ')}. Sending message without those files.`,
+              );
             }
           } else {
             await channel.send('⚠️ Could not resolve agent working directory for file downloads.');
           }
         } catch (err) {
           const errMsg = err instanceof Error ? err.message : String(err);
-          void deps.logger.error('queue:attachment-download', `agent=${agentId} channel=${channelId} error=${errMsg}`);
+          void deps.logger.error(
+            'queue:attachment-download',
+            `agent=${agentId} channel=${channelId} error=${errMsg}`,
+          );
           await channel.send('⚠️ Failed to download attachments. Sending message without them.');
         }
       }
@@ -131,8 +162,13 @@ export function createQueue(deps: QueueDeps) {
 
       if (!result.success || !result.response) {
         const reason = result.error ?? 'The agent could not complete this request.';
-        const hint = readOnly ? '\n-# The agent is in **read-only** mode and cannot modify files.' : '';
-        void deps.logger.error('queue:agent-failure', `agent=${agentId} session=${sessionId ?? 'new'} channel=${channelId} reason=${reason}`);
+        const hint = readOnly
+          ? '\n-# The agent is in **read-only** mode and cannot modify files.'
+          : '';
+        void deps.logger.error(
+          'queue:agent-failure',
+          `agent=${agentId} session=${sessionId ?? 'new'} channel=${channelId} reason=${reason}`,
+        );
         await channel.send(`⚠️ ${reason}${hint}`);
       } else {
         const parts = deps.splitMessage(result.response);
@@ -145,17 +181,21 @@ export function createQueue(deps: QueueDeps) {
       const ctx = (result.usage?.contextUsagePercent ?? 0).toFixed(1);
       const tokens = (result.usage?.inputTokens ?? 0) + (result.usage?.outputTokens ?? 0);
       await channel.send(
-        `-# 💬 ${tokens} tokens • $${cost} • ${ctx}% context${readOnly ? ' • 📖 read-only' : ''}`
+        `-# 💬 ${tokens} tokens • $${cost} • ${ctx}% context${readOnly ? ' • 📖 read-only' : ''}`,
       );
-
     } catch (err) {
       clearInterval(typingInterval);
       try {
         await reaction?.remove();
-      } catch {}
+      } catch {
+        /* reaction cleanup is best-effort */
+      }
 
       const errMsg = err instanceof Error ? err.message : String(err);
-      void deps.logger.error('queue:send-error', `agent=${agentId} session=${sessionId ?? 'new'} channel=${channelId} error=${errMsg}`);
+      void deps.logger.error(
+        'queue:send-error',
+        `agent=${agentId} session=${sessionId ?? 'new'} channel=${channelId} error=${errMsg}`,
+      );
       await channel.send(`❌ Failed to get response from agent:\n\`\`\`\n${errMsg}\n\`\`\``);
     }
 

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -29,7 +29,7 @@ export async function downloadAttachments(
     await mkdir(targetDir, { recursive: true });
   } catch (err) {
     console.warn(`[attachments] Failed to create directory "${targetDir}":`, err);
-    return { downloaded: [], failed: [...attachments.values()].map(a => a.name) };
+    return { downloaded: [], failed: [...attachments.values()].map((a) => a.name) };
   }
 
   const downloaded: DownloadedFile[] = [];


### PR DESCRIPTION
## Summary
- Add `eslint`, `prettier`, `typescript-eslint`, `@eslint/js`, and `eslint-config-prettier` as dev dependencies
- Add `.prettierrc`, `.prettierignore`, and `eslint.config.mjs` configuration files
- Reformat all 23 source/doc files with Prettier
- Fix 8 ESLint issues across 6 files (unused imports, useless assignment, missing error cause, empty catch block)

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 98/98 pass
- [x] `npx eslint .` — 0 errors, 0 warnings
- [x] `npx prettier --check .` — all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)