### PR TITLE
Maestro discord cli documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,55 @@ A Discord bot that connects your server to Maestro AI agents through `maestro-cl
 - A Discord application + bot token
 - Maestro CLI installed and authenticated
 
+### Install Maestro CLI
+
+After installing [Maestro](https://github.com/RunMaestro/Maestro), create a shell wrapper:
+
+```bash
+# macOS (after installing Maestro.app)
+printf '#!/bin/bash\nnode "/Applications/Maestro.app/Contents/Resources/maestro-cli.js" "$@"\n' | sudo tee /usr/local/bin/maestro-cli && sudo chmod +x /usr/local/bin/maestro-cli
+
+# Linux (deb/rpm installs to /opt)
+printf '#!/bin/bash\nnode "/opt/Maestro/resources/maestro-cli.js" "$@"\n' | sudo tee /usr/local/bin/maestro-cli && sudo chmod +x /usr/local/bin/maestro-cli
+
+# Windows (PowerShell as Administrator) - create a batch file
+@"
+@echo off
+node "%ProgramFiles%\Maestro\resources\maestro-cli.js" %*
+"@ | Out-File -FilePath "$env:ProgramFiles\Maestro\maestro-cli.cmd" -Encoding ASCII
+```
+
+Alternatively, run directly with Node.js:
+
+```bash
+node "/Applications/Maestro.app/Contents/Resources/maestro-cli.js" list groups
+```
+
+### Install maestro-discord CLI
+
+After building the project (`npm run build`), create a shell wrapper:
+
+```bash
+# macOS — create a global symlink to the built CLI
+printf '#!/bin/bash\nnode "%s/dist/cli/maestro-discord.js" "$@"\n' "$(pwd)" | sudo tee /usr/local/bin/maestro-discord && sudo chmod +x /usr/local/bin/maestro-discord
+
+# Linux
+printf '#!/bin/bash\nnode "%s/dist/cli/maestro-discord.js" "$@"\n' "$(pwd)" | sudo tee /usr/local/bin/maestro-discord && sudo chmod +x /usr/local/bin/maestro-discord
+
+# Windows (PowerShell as Administrator) - create a batch file
+$repoPath = (Get-Location).Path
+@"
+@echo off
+node "$repoPath\dist\cli\maestro-discord.js" %*
+"@ | Out-File -FilePath "$env:ProgramFiles\maestro-discord.cmd" -Encoding ASCII
+```
+
+Or use `npm link`:
+
+```bash
+npm link
+```
+
 CLI docs: https://docs.runmaestro.ai/
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -14,49 +14,40 @@ A Discord bot that connects your server to Maestro AI agents through `maestro-cl
 
 - Node.js 18+
 - A Discord application + bot token
-- Maestro CLI installed and authenticated
-
-### Install Maestro CLI
-
-After installing [Maestro](https://github.com/RunMaestro/Maestro), create a shell wrapper:
-
-```bash
-# macOS (after installing Maestro.app)
-printf '#!/bin/bash\nnode "/Applications/Maestro.app/Contents/Resources/maestro-cli.js" "$@"\n' | sudo tee /usr/local/bin/maestro-cli && sudo chmod +x /usr/local/bin/maestro-cli
-
-# Linux (deb/rpm installs to /opt)
-printf '#!/bin/bash\nnode "/opt/Maestro/resources/maestro-cli.js" "$@"\n' | sudo tee /usr/local/bin/maestro-cli && sudo chmod +x /usr/local/bin/maestro-cli
-
-# Windows (PowerShell as Administrator) - create a batch file
-@"
-@echo off
-node "%ProgramFiles%\Maestro\resources\maestro-cli.js" %*
-"@ | Out-File -FilePath "$env:ProgramFiles\Maestro\maestro-cli.cmd" -Encoding ASCII
-```
-
-Alternatively, run directly with Node.js:
-
-```bash
-node "/Applications/Maestro.app/Contents/Resources/maestro-cli.js" list groups
-```
+- [Maestro CLI](https://docs.runmaestro.ai/cli) installed and authenticated
 
 ### Install maestro-discord CLI
 
 After building the project (`npm run build`), create a shell wrapper:
 
+macOS — create a global wrapper for the built CLI:
+
 ```bash
-# macOS — create a global symlink to the built CLI
 printf '#!/bin/bash\nnode "%s/dist/cli/maestro-discord.js" "$@"\n' "$(pwd)" | sudo tee /usr/local/bin/maestro-discord && sudo chmod +x /usr/local/bin/maestro-discord
+```
 
-# Linux
+Linux:
+
+```bash
 printf '#!/bin/bash\nnode "%s/dist/cli/maestro-discord.js" "$@"\n' "$(pwd)" | sudo tee /usr/local/bin/maestro-discord && sudo chmod +x /usr/local/bin/maestro-discord
+```
 
-# Windows (PowerShell as Administrator) - create a batch file
+Windows (PowerShell) — writes the wrapper to `%USERPROFILE%\bin` and adds it to your user PATH:
+
+```powershell
 $repoPath = (Get-Location).Path
+$binDir = "$env:USERPROFILE\bin"
+New-Item -ItemType Directory -Force -Path $binDir | Out-Null
 @"
 @echo off
 node "$repoPath\dist\cli\maestro-discord.js" %*
-"@ | Out-File -FilePath "$env:ProgramFiles\maestro-discord.cmd" -Encoding ASCII
+"@ | Out-File -FilePath "$binDir\maestro-discord.cmd" -Encoding ASCII
+
+# Add $binDir to user PATH if it isn't already (restart your shell afterwards)
+$userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+if (-not ($userPath -split ';' -contains $binDir)) {
+    [Environment]::SetEnvironmentVariable('PATH', "$binDir;$userPath", 'User')
+}
 ```
 
 Or use `npm link`:


### PR DESCRIPTION
Added discord cli installation documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added installation instructions for maestro-cli and maestro-discord CLIs.
  * Provided OS-specific setup steps for creating CLI wrappers on macOS, Linux, and Windows.
  * Documented alternative run/install options (direct Node execution and npm link).
  * Clarified that existing prerequisites and quick-start/command guidance remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->