### PR TITLE
feat(session): run /session commands from inside a thread

### DIFF
--- a/src/__tests__/session-command.test.ts
+++ b/src/__tests__/session-command.test.ts
@@ -20,6 +20,7 @@ function makeInteraction(overrides: Record<string, unknown> = {}) {
     },
     channel: {
       isThread: () => false,
+      isSendable: () => true,
       threads: {
         create: mock.fn(async (opts: Record<string, unknown>) => ({
           id: 'thread-new-1',
@@ -89,6 +90,7 @@ test('session new uses provided name', async () => {
   const interaction = makeInteraction({
     channel: {
       isThread: () => false,
+      isSendable: () => true,
       threads: { create: createMock },
     },
     options: {
@@ -123,7 +125,10 @@ test('session new from a thread creates a thread on the parent agent channel', a
     channel: {
       isThread: () => true,
       parentId: 'parent-ch',
-      parent: { threads: { create: parentCreateMock } },
+      parent: {
+        isSendable: () => true,
+        threads: { create: parentCreateMock },
+      },
     },
     options: { getSubcommand: () => 'new', getString: () => null },
   });
@@ -146,7 +151,10 @@ test('session new from a thread whose parent is not an agent channel rejects', a
     channel: {
       isThread: () => true,
       parentId: 'parent-ch',
-      parent: { threads: { create: mock.fn() } },
+      parent: {
+        isSendable: () => true,
+        threads: { create: mock.fn() },
+      },
     },
     options: { getSubcommand: () => 'new', getString: () => null },
   });
@@ -307,7 +315,10 @@ test('session list from a thread lists threads of the parent agent channel', asy
     channel: {
       isThread: () => true,
       parentId: 'parent-ch',
-      parent: { threads: { create: mock.fn() } },
+      parent: {
+        isSendable: () => true,
+        threads: { create: mock.fn() },
+      },
     },
     options: { getSubcommand: () => 'list' },
   });

--- a/src/__tests__/session-command.test.ts
+++ b/src/__tests__/session-command.test.ts
@@ -103,9 +103,51 @@ test('session new uses provided name', async () => {
   assert.equal(createOpts.name, 'My Custom Session');
 });
 
-test('session new rejects when used in a thread', async () => {
+test('session new from a thread creates a thread on the parent agent channel', async () => {
+  const { channelDb, threadDb } = await import('../db');
+  const channelGetMock = mock.method(channelDb, 'get', (id: string) =>
+    id === 'parent-ch'
+      ? { channel_id: 'parent-ch', agent_id: 'agent-1', agent_name: 'TestBot' }
+      : undefined,
+  );
+  const registerMock = mock.method(threadDb, 'register', () => {});
+
+  const parentCreateMock = mock.fn(async (opts: Record<string, unknown>) => ({
+    id: 'thread-from-thread',
+    name: opts.name,
+    send: mock.fn(async () => ({})),
+  }));
+
   const interaction = makeInteraction({
-    channel: { isThread: () => true },
+    channelId: 'thread-src',
+    channel: {
+      isThread: () => true,
+      parentId: 'parent-ch',
+      parent: { threads: { create: parentCreateMock } },
+    },
+    options: { getSubcommand: () => 'new', getString: () => null },
+  });
+
+  await execute(interaction);
+
+  assert.equal(channelGetMock.mock.calls[0].arguments[0], 'parent-ch');
+  assert.equal(parentCreateMock.mock.callCount(), 1);
+  assert.equal(registerMock.mock.callCount(), 1);
+  assert.equal(registerMock.mock.calls[0].arguments[0], 'thread-from-thread');
+  assert.equal(registerMock.mock.calls[0].arguments[1], 'parent-ch');
+  assert.equal(registerMock.mock.calls[0].arguments[2], 'agent-1');
+});
+
+test('session new from a thread whose parent is not an agent channel rejects', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => undefined);
+
+  const interaction = makeInteraction({
+    channel: {
+      isThread: () => true,
+      parentId: 'parent-ch',
+      parent: { threads: { create: mock.fn() } },
+    },
     options: { getSubcommand: () => 'new', getString: () => null },
   });
 
@@ -113,7 +155,20 @@ test('session new rejects when used in a thread', async () => {
 
   assert.equal(interaction.reply.mock.callCount(), 1);
   const reply = interaction.reply.mock.calls[0].arguments[0];
-  assert.ok(reply.content.includes('main agent channel'));
+  assert.ok(reply.content.includes('not connected to an agent'));
+});
+
+test('session new from a thread with no parentId rejects', async () => {
+  const interaction = makeInteraction({
+    channel: { isThread: () => true, parentId: null, parent: null },
+    options: { getSubcommand: () => 'new', getString: () => null },
+  });
+
+  await execute(interaction);
+
+  assert.equal(interaction.reply.mock.callCount(), 1);
+  const reply = interaction.reply.mock.calls[0].arguments[0];
+  assert.ok(reply.content.includes('parent channel'));
 });
 
 test('session new rejects when not in an agent channel', async () => {
@@ -238,16 +293,31 @@ test('session list handles maestro session fetch failure gracefully', async () =
   assert.ok(reply.embeds[0].data.description.includes('No messages yet'));
 });
 
-test('session list rejects when used in a thread', async () => {
+test('session list from a thread lists threads of the parent agent channel', async () => {
+  const { channelDb, threadDb } = await import('../db');
+  mock.method(channelDb, 'get', (id: string) =>
+    id === 'parent-ch'
+      ? { channel_id: 'parent-ch', agent_id: 'agent-1', agent_name: 'TestBot' }
+      : undefined,
+  );
+  const listMock = mock.method(threadDb, 'listByChannel', () => []);
+
   const interaction = makeInteraction({
-    channel: { isThread: () => true },
+    channelId: 'thread-src',
+    channel: {
+      isThread: () => true,
+      parentId: 'parent-ch',
+      parent: { threads: { create: mock.fn() } },
+    },
     options: { getSubcommand: () => 'list' },
   });
 
   await execute(interaction);
 
-  const reply = interaction.reply.mock.calls[0].arguments[0];
-  assert.ok(reply.content.includes('main agent channel'));
+  assert.equal(listMock.mock.calls[0].arguments[0], 'parent-ch');
+  const reply = interaction.editReply.mock.calls[0].arguments[0];
+  assert.ok(typeof reply === 'string');
+  assert.ok(reply.includes('No session threads'));
 });
 
 test('session list rejects non-agent channels', async () => {

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -11,10 +11,13 @@ import { channelDb, threadDb } from '../db';
 import { cleanupAgentFiles } from '../utils/attachments';
 import { config } from '../config';
 
-const MISSING_BOT_SCOPE =
-  '❌ The bot is not a member of this server. It was likely invited with only slash-command permissions.\n\n' +
-  'Re-invite with both `bot` and `applications.commands` scopes:\n' +
-  `https://discord.com/oauth2/authorize?client_id=${config.clientId}&scope=bot+applications.commands&permissions=11344`;
+function missingBotScopeMessage(): string {
+  return (
+    '❌ The bot is not a member of this server. It was likely invited with only slash-command permissions.\n\n' +
+    'Re-invite with both `bot` and `applications.commands` scopes:\n' +
+    `https://discord.com/oauth2/authorize?client_id=${config.clientId}&scope=bot+applications.commands&permissions=11344`
+  );
+}
 
 export const data = new SlashCommandBuilder()
   .setName('agents')
@@ -66,7 +69,9 @@ export async function autocomplete(interaction: AutocompleteInteraction): Promis
 
 export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   if (!interaction.guild) {
-    const msg = interaction.guildId ? MISSING_BOT_SCOPE : 'This command must be used in a server.';
+    const msg = interaction.guildId
+      ? missingBotScopeMessage()
+      : 'This command must be used in a server.';
     if (interaction.deferred || interaction.replied) {
       await interaction.editReply(msg);
     } else {
@@ -139,7 +144,7 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
       : null);
   if (!guild) {
     await interaction.editReply(
-      interaction.guildId ? MISSING_BOT_SCOPE : 'This command must be used in a server.',
+      interaction.guildId ? missingBotScopeMessage() : 'This command must be used in a server.',
     );
     return;
   }

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -34,7 +34,7 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
 
 interface ResolvedAgentChannel {
   channelInfo: AgentChannel;
-  parentChannel: TextChannel;
+  parentChannel: TextChannel | null;
   parentChannelId: string;
 }
 
@@ -42,7 +42,7 @@ async function resolveAgentChannel(
   interaction: ChatInputCommandInteraction,
 ): Promise<ResolvedAgentChannel | undefined> {
   let parentChannelId = interaction.channelId;
-  let parentChannel: TextChannel | null = interaction.channel as TextChannel | null;
+  let parentChannel: TextChannel | null = null;
 
   if (interaction.channel?.isThread()) {
     const parentId = interaction.channel.parentId;
@@ -54,21 +54,18 @@ async function resolveAgentChannel(
       return undefined;
     }
     parentChannelId = parentId;
-    parentChannel = (interaction.channel.parent as TextChannel | null) ?? null;
+    const parent = interaction.channel.parent;
+    if (parent?.isSendable() && 'threads' in parent) {
+      parentChannel = parent as TextChannel;
+    }
+  } else if (interaction.channel?.isSendable() && 'threads' in interaction.channel) {
+    parentChannel = interaction.channel as TextChannel;
   }
 
   const channelInfo = channelDb.get(parentChannelId);
   if (!channelInfo) {
     await interaction.reply({
       content: '❌ This channel is not connected to an agent. Use `/agents connect` first.',
-      ephemeral: true,
-    });
-    return undefined;
-  }
-
-  if (!parentChannel) {
-    await interaction.reply({
-      content: '❌ Could not access the parent agent channel.',
       ephemeral: true,
     });
     return undefined;
@@ -83,6 +80,14 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
     return;
   }
   const { channelInfo, parentChannel, parentChannelId } = resolved;
+
+  if (!parentChannel) {
+    await interaction.reply({
+      content: '❌ Could not access the parent agent channel.',
+      ephemeral: true,
+    });
+    return;
+  }
 
   await interaction.deferReply({ ephemeral: false });
 

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -5,7 +5,7 @@ import {
   TextChannel,
   ThreadAutoArchiveDuration,
 } from 'discord.js';
-import { channelDb, threadDb } from '../db';
+import { AgentChannel, channelDb, threadDb } from '../db';
 import { maestro, MaestroSession } from '../services/maestro';
 
 export const data = new SlashCommandBuilder()
@@ -32,15 +32,32 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
   }
 }
 
-async function validateAgentChannel(interaction: ChatInputCommandInteraction) {
+interface ResolvedAgentChannel {
+  channelInfo: AgentChannel;
+  parentChannel: TextChannel;
+  parentChannelId: string;
+}
+
+async function resolveAgentChannel(
+  interaction: ChatInputCommandInteraction,
+): Promise<ResolvedAgentChannel | undefined> {
+  let parentChannelId = interaction.channelId;
+  let parentChannel: TextChannel | null = interaction.channel as TextChannel | null;
+
   if (interaction.channel?.isThread()) {
-    await interaction.reply({
-      content: '❌ Run this command in the main agent channel, not inside a thread.',
-      ephemeral: true,
-    });
-    return undefined;
+    const parentId = interaction.channel.parentId;
+    if (!parentId) {
+      await interaction.reply({
+        content: '❌ Could not resolve the parent channel for this thread.',
+        ephemeral: true,
+      });
+      return undefined;
+    }
+    parentChannelId = parentId;
+    parentChannel = (interaction.channel.parent as TextChannel | null) ?? null;
   }
-  const channelInfo = channelDb.get(interaction.channelId);
+
+  const channelInfo = channelDb.get(parentChannelId);
   if (!channelInfo) {
     await interaction.reply({
       content: '❌ This channel is not connected to an agent. Use `/agents connect` first.',
@@ -48,14 +65,24 @@ async function validateAgentChannel(interaction: ChatInputCommandInteraction) {
     });
     return undefined;
   }
-  return channelInfo;
+
+  if (!parentChannel) {
+    await interaction.reply({
+      content: '❌ Could not access the parent agent channel.',
+      ephemeral: true,
+    });
+    return undefined;
+  }
+
+  return { channelInfo, parentChannel, parentChannelId };
 }
 
 async function handleNew(interaction: ChatInputCommandInteraction): Promise<void> {
-  const channelInfo = await validateAgentChannel(interaction);
-  if (!channelInfo) {
+  const resolved = await resolveAgentChannel(interaction);
+  if (!resolved) {
     return;
   }
+  const { channelInfo, parentChannel, parentChannelId } = resolved;
 
   await interaction.deferReply({ ephemeral: false });
 
@@ -64,13 +91,13 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
     providedName ??
     `Session ${new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`;
 
-  const thread = await (interaction.channel as TextChannel).threads.create({
+  const thread = await parentChannel.threads.create({
     name: threadName,
     autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
     reason: `Maestro session for agent ${channelInfo.agent_name}`,
   });
 
-  threadDb.register(thread.id, interaction.channelId, channelInfo.agent_id, interaction.user.id);
+  threadDb.register(thread.id, parentChannelId, channelInfo.agent_id, interaction.user.id);
 
   await thread.send(
     `🤖 **${channelInfo.agent_name}** — ready for a new session.\nType your first message to begin. This thread is linked to a dedicated Maestro session.\nOnly <@${interaction.user.id}> can interact with the agent in this thread.`,
@@ -82,14 +109,15 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
 }
 
 async function handleList(interaction: ChatInputCommandInteraction): Promise<void> {
-  const channelInfo = await validateAgentChannel(interaction);
-  if (!channelInfo) {
+  const resolved = await resolveAgentChannel(interaction);
+  if (!resolved) {
     return;
   }
+  const { channelInfo, parentChannelId } = resolved;
 
   await interaction.deferReply({ ephemeral: true });
 
-  const dbThreads = threadDb.listByChannel(interaction.channelId);
+  const dbThreads = threadDb.listByChannel(parentChannelId);
   if (dbThreads.length === 0) {
     await interaction.editReply('No session threads yet. Use `/session new` to create one.');
     return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,10 +18,22 @@ function requiredCsv(key: string): string[] {
 }
 
 export const config = {
-  token: required('DISCORD_BOT_TOKEN'),
-  clientId: required('DISCORD_CLIENT_ID'),
-  guildId: required('DISCORD_GUILD_ID'),
-  allowedUserIds: requiredCsv('DISCORD_ALLOWED_USER_IDS'),
-  apiPort: parseInt(process.env.API_PORT || '3457', 10),
-  mentionUserId: process.env.DISCORD_MENTION_USER_ID || '',
+  get token() {
+    return required('DISCORD_BOT_TOKEN');
+  },
+  get clientId() {
+    return required('DISCORD_CLIENT_ID');
+  },
+  get guildId() {
+    return required('DISCORD_GUILD_ID');
+  },
+  get allowedUserIds() {
+    return requiredCsv('DISCORD_ALLOWED_USER_IDS');
+  },
+  get apiPort() {
+    return parseInt(process.env.API_PORT || '3457', 10);
+  },
+  get mentionUserId() {
+    return process.env.DISCORD_MENTION_USER_ID || '';
+  },
 };


### PR DESCRIPTION
## Summary
- `/session new` and `/session list` can now be invoked from inside a thread of an agent channel. The agent is resolved via the thread's parent channel.
- New session threads created from within a thread are placed on the parent agent channel (sibling to existing session threads), not nested inside the current thread.
- Refactored the shared channel-validation helper into `resolveAgentChannel`, which returns the parent channel reference + ids.

This is the groundwork for a future "fork conversation" feature (tracked as a follow-up — maestro-cli has no branch primitive yet, so forking is deliberately out of scope here).

## Test plan
- [x] `npm test` — 100/100 pass
- [x] `npx eslint "src/**/*.ts"` — no issues
- [x] `npx prettier --check "src/**/*.ts"` — all formatted
- [x] New tests cover: thread → parent agent channel resolution, thread with unregistered parent, thread with no `parentId`, and `/session list` from a thread
- [ ] Manual smoke: run `/session new` from inside a session thread and confirm the new thread appears on the parent agent channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session commands now work within threads, automatically resolving to the parent channel's agent context.

* **Bug Fixes**
  * Added validation to ensure threads are connected to an agent channel; improved error messaging for unsupported thread configurations.
  * Session operations now correctly reference parent channels when invoked in threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->