### PR TITLE
fix(readme): correct OAuth permissions integer for thread + attachment usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,16 +159,18 @@ Delete this file to reset all channel bindings.
 Invite the bot with both `bot` and `applications.commands` scopes:
 
 ```text
-https://discord.com/oauth2/authorize?client_id=<DISCORD_CLIENT_ID>&scope=bot+applications.commands&permissions=11344
+https://discord.com/oauth2/authorize?client_id=<DISCORD_CLIENT_ID>&scope=bot+applications.commands&permissions=309237681232
 ```
 
 This grants the following permissions:
 
-- Manage Channels
-- Add Reactions
+- Manage Channels — create and delete agent channels (`/agents new`, `/agents disconnect`)
 - View Channels
 - Send Messages
-- Manage Messages
+- Attach Files — re-upload user attachments when forwarding to a session thread
+- Add Reactions — `⏳`/`🎧` queue and transcription indicators
+- Create Public Threads — owner-bound session threads
+- Send Messages in Threads
 
 Then enable **Message Content Intent** under Privileged Gateway Intents at:
 


### PR DESCRIPTION
README-only change. Does **not** affect code or tests, but **does** require existing installs to re-invite the bot if a server has revoked thread/attachment permissions for `@everyone` (which is why this bug has been latent).

## The bug

The documented invite URL granted `Manage Messages` but no thread permissions, even though the bot creates and sends to threads:

- `src/handlers/messageCreate.ts:75` — `(message.channel as TextChannel).threads.create(...)` for mention-triggered threads
- `src/commands/session.ts:99` — `parentChannel.threads.create(...)` for `/session new`
- `src/handlers/messageCreate.ts:96` — `thread.send({ files: [...] })` to re-upload attachments

Today the bot works on most Discord servers because `Create Public Threads`, `Send Messages in Threads`, and `Attach Files` are granted to `@everyone` by default. A server that has revoked any of those for `@everyone` would break the bot's `/session new` and mention flow on a fresh install.

## The fix

Permission integer: `11344` → `309237681232`

| Bit | Value | Permission | Change | Why |
|---|---|---|---|---|
| 4 | 16 | Manage Channels | keep | Create/delete agent channels |
| 6 | 64 | Add Reactions | keep | ⏳/🎧 indicators |
| 10 | 1024 | View Channel | keep | |
| 11 | 2048 | Send Messages | keep | |
| 13 | 8192 | Manage Messages | **drop** | No longer used; PR #22 replaced `reaction.remove()` with `reaction.users.remove()` |
| 15 | 32768 | Attach Files | **add** | Re-upload attachments to threads |
| 35 | 34359738368 | Create Public Threads | **add** | `/session new` + mention-triggered threads |
| 38 | 274877906944 | Send Messages in Threads | **add** | Sending to threads |

Total: `16 + 64 + 1024 + 2048 + 32768 + 34359738368 + 274877906944 = 309237681232`

Also adds a one-line rationale next to each granted permission so future readers can audit the set against the code paths that use it.

## Test plan

- [x] `grep` confirms no in-tree usage of `MANAGE_MESSAGES`, `messages.delete`, `reactions.removeAll`, `pin`, `unpin`.
- [x] `grep` confirms `threads.create` is called and `thread.send({ files })` is called.
- [x] No code changes; full test suite is unaffected.
- [ ] Manual: invite the bot to a clean test server with the new URL, run `/session new` and post an attachment, verify both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)