### PR TITLE
feat: verb-based maestro-discord CLI + 5 new slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,18 @@ npm run build && node --test --experimental-test-coverage dist/__tests__/**/*.te
 | `/health`                  | Verify Maestro CLI is installed and working                   |
 | `/agents list`             | Show all available agents                                     |
 | `/agents new <agent>`      | Create a dedicated channel for an agent (autocomplete)        |
+| `/agents show <agent>`     | Show an agent's stats and recent activity                     |
 | `/agents disconnect`       | (Run inside an agent channel) Remove and delete the channel   |
 | `/agents readonly on\|off` | Toggle read-only mode for the current agent channel           |
 | `/session new`             | Create a new owner-bound thread for the current agent channel |
 | `/session list`            | List session threads for the current agent channel            |
+| `/playbook list`           | List playbooks (optionally filter by agent)                   |
+| `/playbook show <id>`      | Show details for a playbook                                   |
+| `/playbook run <id>`       | Run a playbook and post the completion summary in-channel     |
+| `/auto-run start <doc>`    | Launch an Auto Run document for the current agent channel     |
+| `/gist`                    | Publish the current agent's session transcript as a GitHub gist |
+| `/notes synopsis`          | Post an AI-generated synopsis of recent activity              |
+| `/notes history`           | Post a unified history feed across agents                     |
 
 ## How it works
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,18 +9,33 @@ The API server starts automatically with the bot on port 3457 (configurable via 
 
 ## CLI usage
 
+`maestro-discord` is verb-based. Run `maestro-discord --help` for the full
+list, or `maestro-discord <verb> --help` for verb-specific options.
+
 ```bash
-# Send a message to an agent's Discord channel
-maestro-discord --agent <agent-id> --message "Hello from Maestro"
+# Send a plain message to an agent's Discord channel
+maestro-discord send --agent <agent-id> --message "Hello from Maestro"
 
 # Send with @mention (pings the user set in DISCORD_MENTION_USER_ID)
-maestro-discord --agent <agent-id> --message "Build complete!" --mention
+maestro-discord send --agent <agent-id> --message "Build complete!" --mention
 
 # Use a custom port
-maestro-discord --agent <agent-id> --message "Hello" --port 4000
+maestro-discord send --agent <agent-id> --message "Hello" --port 4000
+
+# Post a styled toast notification (color → emoji prefix)
+maestro-discord notify toast \
+  --agent <agent-id> --title "Deploy" --message "Shipped to staging" --color green
+
+# Post a one-line flash with optional second-line detail
+maestro-discord notify flash --agent <agent-id> --message "Build failed" --color red
+
+# Post the agent's current status (cwd, usage, tokens) to its channel
+maestro-discord status --agent <agent-id>
 ```
 
-If the agent doesn't have a connected Discord channel yet, one is created automatically.
+If the agent doesn't have a connected Discord channel yet, `send` creates
+one automatically. `notify` and `status` go to the same channel and ride the
+same `POST /api/send` endpoint internally.
 
 ## Health check
 

--- a/src/__tests__/agents-command.test.ts
+++ b/src/__tests__/agents-command.test.ts
@@ -1,7 +1,7 @@
 import test, { afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { execute, autocomplete } from '../commands/agents';
-import { EMBED_FIELD_VALUE_MAX } from '../utils/embed';
+import { EMBED_FIELD_VALUE_MAX, EMBED_TITLE_MAX } from '../utils/embed';
 
 afterEach(() => {
   mock.restoreAll();
@@ -21,6 +21,7 @@ function makeInteraction(overrides: Record<string, unknown> = {}) {
         create: mock.fn(async (opts: Record<string, unknown>) => ({
           id: 'new-ch-1',
           name: opts.name,
+          isSendable: () => true,
           send: mock.fn(async () => ({})),
         })),
       },
@@ -148,6 +149,79 @@ test('agents new requires a guild', async () => {
   assert.ok(reply.content.includes('must be used in a server'));
 });
 
+test('agents new bounds the channel name to Discord 100-char limit', async () => {
+  const { maestro } = await import('../services/maestro');
+  // 200-char agent name will produce a > 100-char channel name (+ "agent-" prefix).
+  const longName = 'A'.repeat(200);
+  mock.method(maestro, 'listAgents', async () => [
+    { id: 'agent-long', name: longName, toolType: 'claude', cwd: '/proj' },
+  ]);
+
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'register', () => {});
+
+  const interaction = makeInteraction({
+    options: {
+      getSubcommand: () => 'new',
+      getString: (_name: string, _req: boolean) => 'agent-long',
+    },
+  });
+
+  await execute(interaction);
+
+  // create() is called twice: first for the "Maestro Agents" category, then for
+  // the actual agent channel. Find the call that targets the agent channel.
+  const calls = interaction.guild.channels.create.mock.calls;
+  const channelCall = calls.find((c: { arguments: [{ name: string }] }) =>
+    c.arguments[0].name.startsWith('agent-'),
+  );
+  assert.ok(channelCall, 'Expected a channel creation call starting with "agent-"');
+  const passedName = channelCall.arguments[0].name as string;
+  assert.ok(
+    passedName.length <= 100,
+    `Channel name length ${passedName.length} exceeds Discord 100-char limit`,
+  );
+  assert.ok(passedName.startsWith('agent-'));
+});
+
+test('agents new replies with a friendly error when channel is not sendable', async () => {
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'listAgents', async () => [
+    { id: 'agent-abc', name: 'TestBot', toolType: 'claude', cwd: '/proj' },
+  ]);
+
+  const { channelDb } = await import('../db');
+  const registerMock = mock.method(channelDb, 'register', () => {});
+
+  const interaction = makeInteraction({
+    guild: {
+      id: 'guild-1',
+      channels: {
+        cache: { find: () => undefined },
+        create: mock.fn(async (opts: Record<string, unknown>) => ({
+          id: 'new-ch-1',
+          name: opts.name,
+          // Simulate a non-sendable channel (e.g. permissions issue).
+          isSendable: () => false,
+          send: mock.fn(async () => ({})),
+        })),
+      },
+    },
+    options: {
+      getSubcommand: () => 'new',
+      getString: (_name: string, _req: boolean) => 'agent-abc',
+    },
+  });
+
+  await execute(interaction);
+
+  // Should not register the channel when not sendable.
+  assert.equal(registerMock.mock.callCount(), 0);
+  const reply = interaction.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok(reply.includes('Failed to create a sendable channel'));
+});
+
 test('agents new matches agent by prefix', async () => {
   const { maestro } = await import('../services/maestro');
   mock.method(maestro, 'listAgents', async () => [
@@ -239,6 +313,41 @@ test('agents show clamps an oversize cwd value to the field-value limit', async 
   assert.ok(
     cwdField.value.length <= EMBED_FIELD_VALUE_MAX,
     `Cwd field length ${cwdField.value.length} exceeds ${EMBED_FIELD_VALUE_MAX}`,
+  );
+});
+
+test('agents show clamps oversize title and groupName', async () => {
+  const { maestro } = await import('../services/maestro');
+  const longName = 'N'.repeat(EMBED_TITLE_MAX + 500);
+  const longGroup = 'G'.repeat(EMBED_FIELD_VALUE_MAX + 500);
+  mock.method(maestro, 'showAgent', async () => ({
+    id: 'agent-1',
+    name: longName,
+    toolType: 'claude',
+    cwd: '/proj',
+    groupName: longGroup,
+  }));
+
+  const interaction = makeInteraction({
+    options: {
+      getSubcommand: () => 'show',
+      getString: (_name: string, _req: boolean) => 'agent-1',
+    },
+  });
+
+  await execute(interaction);
+
+  const reply = interaction.editReply.mock.calls[0].arguments[0];
+  const data = reply.embeds[0].data;
+  assert.ok(
+    data.title.length <= EMBED_TITLE_MAX,
+    `Title length ${data.title.length} exceeds ${EMBED_TITLE_MAX}`,
+  );
+  const groupField = data.fields.find((f: { name: string }) => f.name === 'Group');
+  assert.ok(groupField, 'Group field should be present');
+  assert.ok(
+    groupField.value.length <= EMBED_FIELD_VALUE_MAX,
+    `Group field length ${groupField.value.length} exceeds ${EMBED_FIELD_VALUE_MAX}`,
   );
 });
 

--- a/src/__tests__/agents-command.test.ts
+++ b/src/__tests__/agents-command.test.ts
@@ -1,6 +1,7 @@
 import test, { afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { execute, autocomplete } from '../commands/agents';
+import { EMBED_FIELD_VALUE_MAX } from '../utils/embed';
 
 afterEach(() => {
   mock.restoreAll();
@@ -167,6 +168,98 @@ test('agents new matches agent by prefix', async () => {
 
   const reply = interaction.editReply.mock.calls[0].arguments[0];
   assert.ok(reply.includes('PrefixBot'));
+});
+
+// --- /agents show ---
+
+test('agents show renders an embed with stats and recent activity', async () => {
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'showAgent', async () => ({
+    id: 'agent-1',
+    name: 'TestBot',
+    toolType: 'claude',
+    cwd: '/proj',
+    groupName: 'Group A',
+    stats: {
+      historyEntries: 12,
+      successCount: 10,
+      failureCount: 2,
+      totalInputTokens: 5000,
+      totalOutputTokens: 1000,
+      totalCost: 0.0123,
+      totalElapsedMs: 5400,
+    },
+    recentHistory: [
+      { id: 'h-1', type: 'CUE', timestamp: Date.now(), summary: 'first', success: true },
+      { id: 'h-2', type: 'CUE', timestamp: Date.now(), summary: 'second', success: false },
+    ],
+  }));
+
+  const interaction = makeInteraction({
+    options: {
+      getSubcommand: () => 'show',
+      getString: (_name: string, _req: boolean) => 'agent-1',
+    },
+  });
+
+  await execute(interaction);
+
+  const reply = interaction.editReply.mock.calls[0].arguments[0];
+  assert.ok(reply.embeds);
+  const data = reply.embeds[0].data;
+  assert.equal(data.title, 'TestBot');
+  const fieldNames = data.fields.map((f: { name: string }) => f.name);
+  assert.ok(fieldNames.includes('Stats'));
+  assert.ok(fieldNames.includes('Recent activity'));
+});
+
+test('agents show clamps an oversize cwd value to the field-value limit', async () => {
+  const { maestro } = await import('../services/maestro');
+  // 2000-char path comfortably exceeds the 1024 field limit (with backticks)
+  const longCwd = '/very/long/path/segment/'.repeat(100);
+  mock.method(maestro, 'showAgent', async () => ({
+    id: 'agent-1',
+    name: 'TestBot',
+    toolType: 'claude',
+    cwd: longCwd,
+  }));
+
+  const interaction = makeInteraction({
+    options: {
+      getSubcommand: () => 'show',
+      getString: (_name: string, _req: boolean) => 'agent-1',
+    },
+  });
+
+  await execute(interaction);
+
+  const reply = interaction.editReply.mock.calls[0].arguments[0];
+  const cwdField = reply.embeds[0].data.fields.find((f: { name: string }) => f.name === 'Cwd');
+  assert.ok(cwdField, 'Cwd field should be present');
+  assert.ok(
+    cwdField.value.length <= EMBED_FIELD_VALUE_MAX,
+    `Cwd field length ${cwdField.value.length} exceeds ${EMBED_FIELD_VALUE_MAX}`,
+  );
+});
+
+test('agents show surfaces a friendly error when load fails', async () => {
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'showAgent', async () => {
+    throw new Error('agent missing');
+  });
+
+  const interaction = makeInteraction({
+    options: {
+      getSubcommand: () => 'show',
+      getString: (_name: string, _req: boolean) => 'agent-x',
+    },
+  });
+
+  await execute(interaction);
+
+  const reply = interaction.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok(reply.includes('Could not load agent'));
 });
 
 // --- /agents disconnect ---

--- a/src/__tests__/auto-run-command.test.ts
+++ b/src/__tests__/auto-run-command.test.ts
@@ -1,7 +1,9 @@
 import test, { afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
+import os from 'os';
+import { promises as fs } from 'fs';
 import path from 'path';
-import { execute } from '../commands/auto-run';
+import { autocomplete, execute, resolveContainedDocPath } from '../commands/auto-run';
 
 afterEach(() => {
   mock.restoreAll();
@@ -102,7 +104,7 @@ test('auto-run start resolves a relative subpath against the agent Auto Run fold
   assert.deepEqual(opts.docs, [path.join('/agents/auto-run-docs', 'subdir/doc.md')]);
 });
 
-test('auto-run start preserves an absolute path verbatim', async () => {
+test('auto-run start accepts an absolute path that lives inside the agent folder', async () => {
   const { channelDb } = await import('../db');
   mock.method(channelDb, 'get', () => ({
     channel_id: 'ch-1',
@@ -111,22 +113,25 @@ test('auto-run start preserves an absolute path verbatim', async () => {
   }));
 
   const { maestro } = await import('../services/maestro');
-  // showAgent should not even be called when the path is absolute.
-  const showAgentMock = mock.method(maestro, 'showAgent', async () => {
-    throw new Error('should not be called');
-  });
+  mock.method(maestro, 'showAgent', async () => ({
+    id: 'agent-1',
+    name: 'TestBot',
+    toolType: 'claude',
+    cwd: '/proj',
+    autoRunFolderPath: '/agents/auto-run-docs',
+  }));
   const startMock = mock.method(maestro, 'startAutoRun', async () => '');
 
-  const i = makeInteraction({ doc: '/abs/path/doc.md' });
+  const inside = '/agents/auto-run-docs/subdir/doc.md';
+  const i = makeInteraction({ doc: inside });
   await execute(i as unknown as Parameters<typeof execute>[0]);
 
-  assert.equal(showAgentMock.mock.callCount(), 0);
   assert.equal(startMock.mock.callCount(), 1);
   const opts = startMock.mock.calls[0].arguments[0] as { docs: string[] };
-  assert.deepEqual(opts.docs, ['/abs/path/doc.md']);
+  assert.deepEqual(opts.docs, [inside]);
 });
 
-test('auto-run start uses the doc as-is when showAgent fails to resolve a folder', async () => {
+test('auto-run start rejects an absolute path outside the agent folder', async () => {
   const { channelDb } = await import('../db');
   mock.method(channelDb, 'get', () => ({
     channel_id: 'ch-1',
@@ -135,7 +140,60 @@ test('auto-run start uses the doc as-is when showAgent fails to resolve a folder
   }));
 
   const { maestro } = await import('../services/maestro');
-  // showAgent throws — getAgentFolder should swallow and return null.
+  mock.method(maestro, 'showAgent', async () => ({
+    id: 'agent-1',
+    name: 'TestBot',
+    toolType: 'claude',
+    cwd: '/proj',
+    autoRunFolderPath: '/agents/auto-run-docs',
+  }));
+  const startMock = mock.method(maestro, 'startAutoRun', async () => '');
+
+  const i = makeInteraction({ doc: '/etc/passwd' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  assert.equal(startMock.mock.callCount(), 0);
+  const reply = i.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok((reply as string).includes('inside'));
+});
+
+test('auto-run start rejects relative paths that escape the folder via traversal', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'showAgent', async () => ({
+    id: 'agent-1',
+    name: 'TestBot',
+    toolType: 'claude',
+    cwd: '/proj',
+    autoRunFolderPath: '/agents/auto-run-docs',
+  }));
+  const startMock = mock.method(maestro, 'startAutoRun', async () => '');
+
+  const i = makeInteraction({ doc: '../../etc/passwd' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  assert.equal(startMock.mock.callCount(), 0);
+  const reply = i.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok((reply as string).includes('inside'));
+});
+
+test('auto-run start rejects when showAgent fails to resolve a folder', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
   mock.method(maestro, 'showAgent', async () => {
     throw new Error('cli unavailable');
   });
@@ -144,12 +202,13 @@ test('auto-run start uses the doc as-is when showAgent fails to resolve a folder
   const i = makeInteraction({ doc: 'plan.md' });
   await execute(i as unknown as Parameters<typeof execute>[0]);
 
-  assert.equal(startMock.mock.callCount(), 1);
-  const opts = startMock.mock.calls[0].arguments[0] as { docs: string[] };
-  assert.deepEqual(opts.docs, ['plan.md']);
+  assert.equal(startMock.mock.callCount(), 0);
+  const reply = i.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok((reply as string).includes('Auto Run folder'));
 });
 
-test('auto-run start uses the doc as-is when autoRunFolderPath is missing', async () => {
+test('auto-run start rejects when autoRunFolderPath is missing on the agent', async () => {
   const { channelDb } = await import('../db');
   mock.method(channelDb, 'get', () => ({
     channel_id: 'ch-1',
@@ -170,9 +229,45 @@ test('auto-run start uses the doc as-is when autoRunFolderPath is missing', asyn
   const i = makeInteraction({ doc: 'plan.md' });
   await execute(i as unknown as Parameters<typeof execute>[0]);
 
-  assert.equal(startMock.mock.callCount(), 1);
-  const opts = startMock.mock.calls[0].arguments[0] as { docs: string[] };
-  assert.deepEqual(opts.docs, ['plan.md']);
+  assert.equal(startMock.mock.callCount(), 0);
+  const reply = i.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok((reply as string).includes('Auto Run folder'));
+});
+
+// --- resolveContainedDocPath unit tests ---
+
+test('resolveContainedDocPath resolves a bare filename inside the folder', () => {
+  const out = resolveContainedDocPath('/agents/auto', 'plan.md');
+  assert.equal(out, path.resolve('/agents/auto', 'plan.md'));
+});
+
+test('resolveContainedDocPath resolves a relative subpath inside the folder', () => {
+  const out = resolveContainedDocPath('/agents/auto', 'subdir/plan.md');
+  assert.equal(out, path.resolve('/agents/auto', 'subdir/plan.md'));
+});
+
+test('resolveContainedDocPath accepts an absolute path inside the folder', () => {
+  const out = resolveContainedDocPath('/agents/auto', '/agents/auto/x/y.md');
+  assert.equal(out, path.resolve('/agents/auto/x/y.md'));
+});
+
+test('resolveContainedDocPath rejects an absolute path outside the folder', () => {
+  assert.equal(resolveContainedDocPath('/agents/auto', '/etc/passwd'), null);
+});
+
+test('resolveContainedDocPath rejects relative traversal that escapes the folder', () => {
+  assert.equal(resolveContainedDocPath('/agents/auto', '../../etc/passwd'), null);
+});
+
+test('resolveContainedDocPath rejects an exact match of the folder itself', () => {
+  assert.equal(resolveContainedDocPath('/agents/auto', '.'), null);
+});
+
+test('resolveContainedDocPath rejects sibling-prefix paths that look similar', () => {
+  // /agents/auto-evil starts with "/agents/auto" as a string but is a
+  // different directory. Containment must use a separator boundary.
+  assert.equal(resolveContainedDocPath('/agents/auto', '/agents/auto-evil/x.md'), null);
 });
 
 test('auto-run start surfaces errors from startAutoRun', async () => {
@@ -202,4 +297,77 @@ test('auto-run start surfaces errors from startAutoRun', async () => {
   assert.equal(typeof reply, 'string');
   assert.ok((reply as string).includes('Auto Run failed to launch'));
   assert.ok((reply as string).includes('boom'));
+});
+
+// --- autocomplete ---
+
+test('auto-run autocomplete includes nested .md files using forward slashes', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-run-ac-'));
+  try {
+    await fs.writeFile(path.join(tmp, 'top.md'), '#');
+    await fs.mkdir(path.join(tmp, 'sub'), { recursive: true });
+    await fs.writeFile(path.join(tmp, 'sub', 'nested.md'), '#');
+    await fs.mkdir(path.join(tmp, 'sub', 'deeper'), { recursive: true });
+    await fs.writeFile(path.join(tmp, 'sub', 'deeper', 'plan.md'), '#');
+    // Non-md file should be ignored
+    await fs.writeFile(path.join(tmp, 'sub', 'README.txt'), 'x');
+
+    const { channelDb } = await import('../db');
+    mock.method(channelDb, 'get', () => ({
+      channel_id: 'ch-1',
+      agent_id: 'agent-1',
+      agent_name: 'TestBot',
+    }));
+
+    const { maestro } = await import('../services/maestro');
+    mock.method(maestro, 'showAgent', async () => ({
+      id: 'agent-1',
+      name: 'TestBot',
+      toolType: 'claude',
+      cwd: '/proj',
+      autoRunFolderPath: tmp,
+    }));
+
+    const responded: Array<Array<{ name: string; value: string }>> = [];
+    const i = {
+      channelId: 'ch-1',
+      options: {
+        getFocused: () => ({ name: 'doc', value: '' }),
+      },
+      respond: mock.fn(async (items: Array<{ name: string; value: string }>) => {
+        responded.push(items);
+      }),
+    };
+
+    await autocomplete(i as unknown as Parameters<typeof autocomplete>[0]);
+
+    assert.equal(responded.length, 1);
+    const values = responded[0].map((entry) => entry.value);
+    assert.ok(values.includes('top.md'));
+    assert.ok(values.includes('sub/nested.md'));
+    assert.ok(values.includes('sub/deeper/plan.md'));
+    // Non-md file must not appear
+    assert.ok(!values.some((v) => v.endsWith('.txt')));
+    // No backslashes regardless of platform
+    for (const v of values) assert.ok(!v.includes('\\'), `value ${v} should not contain \\`);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('auto-run autocomplete returns empty when channel is not registered', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => undefined);
+
+  const responded: unknown[] = [];
+  const i = {
+    channelId: 'ch-x',
+    options: { getFocused: () => ({ name: 'doc', value: '' }) },
+    respond: mock.fn(async (items: unknown) => {
+      responded.push(items);
+    }),
+  };
+
+  await autocomplete(i as unknown as Parameters<typeof autocomplete>[0]);
+  assert.deepEqual(responded[0], []);
 });

--- a/src/__tests__/auto-run-command.test.ts
+++ b/src/__tests__/auto-run-command.test.ts
@@ -1,0 +1,202 @@
+import test, { afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { execute } from '../commands/auto-run';
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+interface MockInteraction {
+  channelId: string;
+  options: {
+    getSubcommand: () => string;
+    getString: (name: string, required?: boolean) => string | null;
+    getInteger: (name: string) => number | null;
+    getBoolean: (name: string) => boolean | null;
+  };
+  deferReply: ReturnType<typeof mock.fn>;
+  editReply: ReturnType<typeof mock.fn>;
+  reply: ReturnType<typeof mock.fn>;
+}
+
+function makeInteraction(
+  options: Record<string, string | number | boolean | null> = {},
+): MockInteraction {
+  return {
+    channelId: 'ch-1',
+    options: {
+      getSubcommand: () => 'start',
+      getString: (name: string) => (options[name] as string | null) ?? null,
+      getInteger: (name: string) => (options[name] as number | null) ?? null,
+      getBoolean: (name: string) => (options[name] as boolean | null) ?? null,
+    },
+    deferReply: mock.fn(async () => {}),
+    editReply: mock.fn(async () => {}),
+    reply: mock.fn(async () => {}),
+  };
+}
+
+test('auto-run start rejects channels not connected to an agent', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => undefined);
+
+  const i = makeInteraction({ doc: 'plan.md' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const reply = i.reply.mock.calls[0].arguments[0] as { content: string };
+  assert.ok(reply.content.includes('not connected to an agent'));
+});
+
+test('auto-run start resolves a bare filename against the agent Auto Run folder', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'showAgent', async () => ({
+    id: 'agent-1',
+    name: 'TestBot',
+    toolType: 'claude',
+    cwd: '/proj',
+    autoRunFolderPath: '/agents/auto-run-docs',
+  }));
+
+  const startMock = mock.method(maestro, 'startAutoRun', async () => '');
+
+  const i = makeInteraction({ doc: 'plan.md' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  assert.equal(startMock.mock.callCount(), 1);
+  const opts = startMock.mock.calls[0].arguments[0] as { docs: string[] };
+  assert.deepEqual(opts.docs, [path.join('/agents/auto-run-docs', 'plan.md')]);
+});
+
+test('auto-run start resolves a relative subpath against the agent Auto Run folder', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'showAgent', async () => ({
+    id: 'agent-1',
+    name: 'TestBot',
+    toolType: 'claude',
+    cwd: '/proj',
+    autoRunFolderPath: '/agents/auto-run-docs',
+  }));
+
+  const startMock = mock.method(maestro, 'startAutoRun', async () => '');
+
+  const i = makeInteraction({ doc: 'subdir/doc.md' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  assert.equal(startMock.mock.callCount(), 1);
+  const opts = startMock.mock.calls[0].arguments[0] as { docs: string[] };
+  assert.deepEqual(opts.docs, [path.join('/agents/auto-run-docs', 'subdir/doc.md')]);
+});
+
+test('auto-run start preserves an absolute path verbatim', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  // showAgent should not even be called when the path is absolute.
+  const showAgentMock = mock.method(maestro, 'showAgent', async () => {
+    throw new Error('should not be called');
+  });
+  const startMock = mock.method(maestro, 'startAutoRun', async () => '');
+
+  const i = makeInteraction({ doc: '/abs/path/doc.md' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  assert.equal(showAgentMock.mock.callCount(), 0);
+  const opts = startMock.mock.calls[0].arguments[0] as { docs: string[] };
+  assert.deepEqual(opts.docs, ['/abs/path/doc.md']);
+});
+
+test('auto-run start uses the doc as-is when showAgent fails to resolve a folder', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  // showAgent throws — getAgentFolder should swallow and return null.
+  mock.method(maestro, 'showAgent', async () => {
+    throw new Error('cli unavailable');
+  });
+  const startMock = mock.method(maestro, 'startAutoRun', async () => '');
+
+  const i = makeInteraction({ doc: 'plan.md' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const opts = startMock.mock.calls[0].arguments[0] as { docs: string[] };
+  assert.deepEqual(opts.docs, ['plan.md']);
+});
+
+test('auto-run start uses the doc as-is when autoRunFolderPath is missing', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'showAgent', async () => ({
+    id: 'agent-1',
+    name: 'TestBot',
+    toolType: 'claude',
+    cwd: '/proj',
+    // autoRunFolderPath intentionally absent
+  }));
+  const startMock = mock.method(maestro, 'startAutoRun', async () => '');
+
+  const i = makeInteraction({ doc: 'plan.md' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const opts = startMock.mock.calls[0].arguments[0] as { docs: string[] };
+  assert.deepEqual(opts.docs, ['plan.md']);
+});
+
+test('auto-run start surfaces errors from startAutoRun', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'showAgent', async () => ({
+    id: 'agent-1',
+    name: 'TestBot',
+    toolType: 'claude',
+    cwd: '/proj',
+    autoRunFolderPath: '/agents/auto-run-docs',
+  }));
+  mock.method(maestro, 'startAutoRun', async () => {
+    throw new Error('boom');
+  });
+
+  const i = makeInteraction({ doc: 'plan.md' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const reply = i.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok((reply as string).includes('Auto Run failed to launch'));
+  assert.ok((reply as string).includes('boom'));
+});

--- a/src/__tests__/auto-run-command.test.ts
+++ b/src/__tests__/auto-run-command.test.ts
@@ -121,6 +121,7 @@ test('auto-run start preserves an absolute path verbatim', async () => {
   await execute(i as unknown as Parameters<typeof execute>[0]);
 
   assert.equal(showAgentMock.mock.callCount(), 0);
+  assert.equal(startMock.mock.callCount(), 1);
   const opts = startMock.mock.calls[0].arguments[0] as { docs: string[] };
   assert.deepEqual(opts.docs, ['/abs/path/doc.md']);
 });
@@ -143,6 +144,7 @@ test('auto-run start uses the doc as-is when showAgent fails to resolve a folder
   const i = makeInteraction({ doc: 'plan.md' });
   await execute(i as unknown as Parameters<typeof execute>[0]);
 
+  assert.equal(startMock.mock.callCount(), 1);
   const opts = startMock.mock.calls[0].arguments[0] as { docs: string[] };
   assert.deepEqual(opts.docs, ['plan.md']);
 });
@@ -168,6 +170,7 @@ test('auto-run start uses the doc as-is when autoRunFolderPath is missing', asyn
   const i = makeInteraction({ doc: 'plan.md' });
   await execute(i as unknown as Parameters<typeof execute>[0]);
 
+  assert.equal(startMock.mock.callCount(), 1);
   const opts = startMock.mock.calls[0].arguments[0] as { docs: string[] };
   assert.deepEqual(opts.docs, ['plan.md']);
 });

--- a/src/__tests__/cli-lib.test.ts
+++ b/src/__tests__/cli-lib.test.ts
@@ -83,9 +83,16 @@ test('postToSendApi rejects with timeout error when server stalls', async () => 
 });
 
 test('postToSendApi reports a friendly message on ECONNREFUSED', async () => {
-  // Use a port that nothing is listening on. Picking 1 is reliably refused.
+  // Bind a server to a random free port, then close it immediately. The OS
+  // won't reassign the port instantly, so connecting to it gets refused
+  // predictably across platforms (port 1 isn't reliably refused on Windows).
+  const probe = http.createServer();
+  await new Promise<void>((resolve) => probe.listen(0, '127.0.0.1', resolve));
+  const port = (probe.address() as AddressInfo).port;
+  await new Promise<void>((resolve) => probe.close(() => resolve()));
+
   await assert.rejects(
-    postToSendApi({ agentId: 'a-1', message: 'hi' }, 1, 1000),
+    postToSendApi({ agentId: 'a-1', message: 'hi' }, port, 1000),
     /not running|not started|ECONNREFUSED/i,
   );
 });

--- a/src/__tests__/cli-lib.test.ts
+++ b/src/__tests__/cli-lib.test.ts
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'http';
+import { AddressInfo } from 'net';
+import { DEFAULT_PORT, parsePort, postToSendApi } from '../cli/lib';
+
+// --- parsePort ---
+
+test('parsePort returns the fallback when value is undefined', () => {
+  assert.equal(parsePort(undefined), DEFAULT_PORT);
+  assert.equal(parsePort(undefined, 9999), 9999);
+});
+
+test('parsePort accepts valid integer port strings', () => {
+  assert.equal(parsePort('1'), 1);
+  assert.equal(parsePort('80'), 80);
+  assert.equal(parsePort('3457'), 3457);
+  assert.equal(parsePort('65535'), 65535);
+});
+
+test('parsePort rejects values with non-digit characters', () => {
+  assert.throws(() => parsePort('123abc'), /must be an integer/);
+  assert.throws(() => parsePort('abc'), /must be an integer/);
+  assert.throws(() => parsePort(' 80'), /must be an integer/);
+  assert.throws(() => parsePort('80 '), /must be an integer/);
+  assert.throws(() => parsePort('-80'), /must be an integer/);
+  assert.throws(() => parsePort('80.5'), /must be an integer/);
+  assert.throws(() => parsePort('0x50'), /must be an integer/);
+});
+
+test('parsePort rejects empty string', () => {
+  assert.throws(() => parsePort(''), /must be an integer/);
+});
+
+test('parsePort rejects values out of TCP range', () => {
+  assert.throws(() => parsePort('0'), /1 and 65535/);
+  assert.throws(() => parsePort('65536'), /1 and 65535/);
+  assert.throws(() => parsePort('99999'), /1 and 65535/);
+});
+
+// --- postToSendApi ---
+
+test('postToSendApi resolves with parsed JSON on success', async () => {
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      const parsed = JSON.parse(body);
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ success: true, channelId: 'ch-' + parsed.agentId }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  try {
+    const result = await postToSendApi({ agentId: 'a-1', message: 'hi' }, port);
+    assert.equal(result.success, true);
+    assert.equal(result.channelId, 'ch-a-1');
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test('postToSendApi rejects with timeout error when server stalls', async () => {
+  // A server that accepts the request but never responds.
+  const server = http.createServer(() => {
+    /* never calls res.end */
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  try {
+    await assert.rejects(
+      postToSendApi({ agentId: 'a-1', message: 'hi' }, port, 100),
+      /timed out/i,
+    );
+  } finally {
+    // closeAllConnections required to free the stalled socket
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test('postToSendApi reports a friendly message on ECONNREFUSED', async () => {
+  // Use a port that nothing is listening on. Picking 1 is reliably refused.
+  await assert.rejects(
+    postToSendApi({ agentId: 'a-1', message: 'hi' }, 1, 1000),
+    /not running|not started|ECONNREFUSED/i,
+  );
+});
+
+test('postToSendApi rejects on invalid JSON response', async () => {
+  const server = http.createServer((_req, res) => {
+    res.end('not-json{{{');
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  try {
+    await assert.rejects(
+      postToSendApi({ agentId: 'a-1', message: 'hi' }, port),
+      /Invalid response from bot/,
+    );
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test('postToSendApi only settles once when timeout fires', async () => {
+  // Server accepts but is slow; we set a tight timeout so the timer fires first,
+  // then the server eventually responds. The promise must already be settled.
+  const server = http.createServer((_req, res) => {
+    setTimeout(() => res.end(JSON.stringify({ success: true })), 200);
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  try {
+    await assert.rejects(
+      postToSendApi({ agentId: 'a-1', message: 'hi' }, port, 50),
+      /timed out/i,
+    );
+    // Wait long enough for the slow server to attempt a response.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    // If the timeout fix is wrong, the second resolve/reject would throw an
+    // UnhandledPromiseRejection here. Surviving the wait is the assertion.
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});

--- a/src/__tests__/embed.test.ts
+++ b/src/__tests__/embed.test.ts
@@ -3,9 +3,11 @@ import assert from 'node:assert/strict';
 import {
   EMBED_DESCRIPTION_MAX,
   EMBED_FIELD_VALUE_MAX,
+  EMBED_TITLE_MAX,
   clampDescription,
   clampFieldValue,
   clampText,
+  clampTitle,
 } from '../utils/embed';
 
 test('clampText returns input unchanged when within limit', () => {
@@ -33,4 +35,15 @@ test('clampFieldValue enforces the 1024 field-value limit', () => {
   const huge = 'y'.repeat(EMBED_FIELD_VALUE_MAX + 500);
   const out = clampFieldValue(huge);
   assert.equal(out.length, EMBED_FIELD_VALUE_MAX);
+});
+
+test('clampTitle enforces the 256 title limit', () => {
+  const huge = 'z'.repeat(EMBED_TITLE_MAX + 500);
+  const out = clampTitle(huge);
+  assert.equal(out.length, EMBED_TITLE_MAX);
+  assert.ok(out.endsWith('\n…'));
+});
+
+test('clampTitle leaves short titles unchanged', () => {
+  assert.equal(clampTitle('My Title'), 'My Title');
 });

--- a/src/__tests__/embed.test.ts
+++ b/src/__tests__/embed.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  EMBED_DESCRIPTION_MAX,
+  EMBED_FIELD_VALUE_MAX,
+  clampDescription,
+  clampFieldValue,
+  clampText,
+} from '../utils/embed';
+
+test('clampText returns input unchanged when within limit', () => {
+  assert.equal(clampText('hello', 10), 'hello');
+  assert.equal(clampText('a'.repeat(10), 10), 'a'.repeat(10));
+});
+
+test('clampText truncates and appends ellipsis marker when over limit', () => {
+  const out = clampText('a'.repeat(20), 10);
+  assert.equal(out.length, 10);
+  assert.ok(out.endsWith('\n…'));
+});
+
+test('clampText hard-slices when limit is shorter than ellipsis marker', () => {
+  assert.equal(clampText('hello', 1), 'h');
+});
+
+test('clampDescription enforces the 4096 description limit', () => {
+  const huge = 'x'.repeat(EMBED_DESCRIPTION_MAX + 500);
+  const out = clampDescription(huge);
+  assert.equal(out.length, EMBED_DESCRIPTION_MAX);
+});
+
+test('clampFieldValue enforces the 1024 field-value limit', () => {
+  const huge = 'y'.repeat(EMBED_FIELD_VALUE_MAX + 500);
+  const out = clampFieldValue(huge);
+  assert.equal(out.length, EMBED_FIELD_VALUE_MAX);
+});

--- a/src/__tests__/gist-command.test.ts
+++ b/src/__tests__/gist-command.test.ts
@@ -154,4 +154,11 @@ test('gist truncates very long error messages to 1500 chars', async () => {
   const reply = i.editReply.mock.calls[0].arguments[0] as string;
   // header text "❌ Could not publish gist: " is added on top of 1500 chars
   assert.ok(reply.length <= 1500 + 50);
+  // Lower bound catches over-truncation regressions: the body must still
+  // contain ~1500 chars of the original error.
+  assert.ok(
+    reply.length >= 1500,
+    `reply length ${reply.length} indicates over-truncation`,
+  );
+  assert.ok(reply.startsWith('❌ Could not publish gist:'));
 });

--- a/src/__tests__/gist-command.test.ts
+++ b/src/__tests__/gist-command.test.ts
@@ -1,0 +1,157 @@
+import test, { afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { execute } from '../commands/gist';
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+interface MockInteraction {
+  channelId: string;
+  options: {
+    getString: (name: string, required?: boolean) => string | null;
+    getBoolean: (name: string) => boolean | null;
+  };
+  deferReply: ReturnType<typeof mock.fn>;
+  editReply: ReturnType<typeof mock.fn>;
+  reply: ReturnType<typeof mock.fn>;
+}
+
+function makeInteraction(
+  options: Record<string, string | boolean | null> = {},
+): MockInteraction {
+  return {
+    channelId: 'ch-1',
+    options: {
+      getString: (name: string) => (options[name] as string | null) ?? null,
+      getBoolean: (name: string) => (options[name] as boolean | null) ?? null,
+    },
+    deferReply: mock.fn(async () => {}),
+    editReply: mock.fn(async () => {}),
+    reply: mock.fn(async () => {}),
+  };
+}
+
+test('gist rejects channels not connected to an agent', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => undefined);
+
+  const i = makeInteraction();
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const reply = i.reply.mock.calls[0].arguments[0] as { content: string };
+  assert.ok(reply.content.includes('not connected to an agent'));
+});
+
+test('gist publishes and renders an embed with the gist url', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'createGist', async () => ({
+    url: 'https://gist.example/abc',
+    id: 'abc',
+  }));
+
+  const i = makeInteraction({ description: 'desc', public: true });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const reply = i.editReply.mock.calls[0].arguments[0] as {
+    embeds: { data: { url: string; title: string; description: string } }[];
+  };
+  assert.equal(reply.embeds[0].data.url, 'https://gist.example/abc');
+  assert.ok(reply.embeds[0].data.title.includes('TestBot'));
+  assert.ok(reply.embeds[0].data.description.includes('public'));
+});
+
+test('gist surfaces a friendly error when createGist throws an Error', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'createGist', async () => {
+    throw new Error('gh not authenticated');
+  });
+
+  const i = makeInteraction();
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const reply = i.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok((reply as string).includes('Could not publish gist'));
+  assert.ok((reply as string).includes('gh not authenticated'));
+});
+
+test('gist tolerates non-Error throws (string)', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  // Reject with a non-Error value — must not blow up the catch handler.
+  mock.method(maestro, 'createGist', async () => {
+    throw 'plain string failure';
+  });
+
+  const i = makeInteraction();
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const reply = i.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok((reply as string).includes('Could not publish gist'));
+  assert.ok((reply as string).includes('plain string failure'));
+});
+
+test('gist tolerates non-Error throws (object without message)', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'createGist', async () => {
+    throw { code: 42 };
+  });
+
+  const i = makeInteraction();
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const reply = i.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok((reply as string).includes('Could not publish gist'));
+});
+
+test('gist truncates very long error messages to 1500 chars', async () => {
+  const { channelDb } = await import('../db');
+  mock.method(channelDb, 'get', () => ({
+    channel_id: 'ch-1',
+    agent_id: 'agent-1',
+    agent_name: 'TestBot',
+  }));
+
+  const { maestro } = await import('../services/maestro');
+  const huge = 'x'.repeat(5000);
+  mock.method(maestro, 'createGist', async () => {
+    throw new Error(huge);
+  });
+
+  const i = makeInteraction();
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const reply = i.editReply.mock.calls[0].arguments[0] as string;
+  // header text "❌ Could not publish gist: " is added on top of 1500 chars
+  assert.ok(reply.length <= 1500 + 50);
+});

--- a/src/__tests__/playbook-command.test.ts
+++ b/src/__tests__/playbook-command.test.ts
@@ -1,7 +1,11 @@
 import test, { afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { execute } from '../commands/playbook';
-import { EMBED_DESCRIPTION_MAX, EMBED_FIELD_VALUE_MAX } from '../utils/embed';
+import {
+  EMBED_DESCRIPTION_MAX,
+  EMBED_FIELD_VALUE_MAX,
+  EMBED_TITLE_MAX,
+} from '../utils/embed';
 
 afterEach(() => {
   mock.restoreAll();
@@ -92,6 +96,41 @@ test('playbook show clamps oversize description and document field', async () =>
   const docs = data.fields.find((f) => f.name === 'Documents');
   assert.ok(docs, 'Documents field should be present');
   assert.ok(docs!.value.length <= EMBED_FIELD_VALUE_MAX);
+});
+
+test('playbook show clamps oversize title and agent name', async () => {
+  const { maestro } = await import('../services/maestro');
+  const longName = 'P'.repeat(EMBED_TITLE_MAX + 500);
+  const longAgent = 'A'.repeat(EMBED_FIELD_VALUE_MAX + 500);
+  mock.method(maestro, 'showPlaybook', async () => ({
+    id: 'pb-1',
+    name: longName,
+    description: 'short',
+    documentCount: 1,
+    taskCount: 1,
+    agentName: longAgent,
+    documents: [],
+  }));
+
+  const i = makeInteraction('show', { playbook: 'pb-1' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  type EmbedData = {
+    title: string;
+    fields: { name: string; value: string }[];
+  };
+  const reply = i.editReply.mock.calls[0].arguments[0] as { embeds: { data: EmbedData }[] };
+  const data = reply.embeds[0].data;
+  assert.ok(
+    data.title.length <= EMBED_TITLE_MAX,
+    `Title length ${data.title.length} exceeds ${EMBED_TITLE_MAX}`,
+  );
+  const agentField = data.fields.find((f) => f.name === 'Agent');
+  assert.ok(agentField, 'Agent field should be present');
+  assert.ok(
+    agentField!.value.length <= EMBED_FIELD_VALUE_MAX,
+    `Agent field length ${agentField!.value.length} exceeds ${EMBED_FIELD_VALUE_MAX}`,
+  );
 });
 
 test('playbook show surfaces a friendly error when load fails', async () => {

--- a/src/__tests__/playbook-command.test.ts
+++ b/src/__tests__/playbook-command.test.ts
@@ -1,0 +1,109 @@
+import test, { afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { execute } from '../commands/playbook';
+import { EMBED_DESCRIPTION_MAX, EMBED_FIELD_VALUE_MAX } from '../utils/embed';
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+interface MockInteraction {
+  options: {
+    getSubcommand: () => string;
+    getString: (name: string, required?: boolean) => string | null;
+  };
+  deferReply: ReturnType<typeof mock.fn>;
+  editReply: ReturnType<typeof mock.fn>;
+  reply: ReturnType<typeof mock.fn>;
+}
+
+function makeInteraction(sub: string, options: Record<string, string | null> = {}): MockInteraction {
+  return {
+    options: {
+      getSubcommand: () => sub,
+      getString: (name: string) => options[name] ?? null,
+    },
+    deferReply: mock.fn(async () => {}),
+    editReply: mock.fn(async () => {}),
+    reply: mock.fn(async () => {}),
+  };
+}
+
+test('playbook list renders an embed with playbooks', async () => {
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'listPlaybooks', async () => [
+    {
+      id: 'pb-1',
+      name: 'Build & Test',
+      description: '',
+      documentCount: 2,
+      taskCount: 7,
+      agentName: 'Alpha',
+    },
+  ]);
+
+  const i = makeInteraction('list');
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const reply = i.editReply.mock.calls[0].arguments[0] as { embeds: { data: { description: string } }[] };
+  assert.ok(reply.embeds);
+  assert.ok(reply.embeds[0].data.description.includes('Build & Test'));
+  assert.ok(reply.embeds[0].data.description.includes('Alpha'));
+});
+
+test('playbook list shows a friendly message when no playbooks exist', async () => {
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'listPlaybooks', async () => []);
+
+  const i = makeInteraction('list');
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const reply = i.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok((reply as string).includes('No playbooks'));
+});
+
+test('playbook show clamps oversize description and document field', async () => {
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'showPlaybook', async () => ({
+    id: 'pb-1',
+    name: 'Big Playbook',
+    description: 'd'.repeat(EMBED_DESCRIPTION_MAX + 1000),
+    documentCount: 30,
+    taskCount: 60,
+    documents: Array.from({ length: 15 }, (_, i) => ({
+      path: '/very/long/path/segment/'.repeat(20) + `doc-${i}.md`,
+      taskCount: 5,
+      completedCount: 1,
+    })),
+  }));
+
+  const i = makeInteraction('show', { playbook: 'pb-1' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  type EmbedData = {
+    description: string;
+    fields: { name: string; value: string }[];
+  };
+  const reply = i.editReply.mock.calls[0].arguments[0] as { embeds: { data: EmbedData }[] };
+  const data = reply.embeds[0].data;
+  assert.ok(data.description.length <= EMBED_DESCRIPTION_MAX);
+
+  const docs = data.fields.find((f) => f.name === 'Documents');
+  assert.ok(docs, 'Documents field should be present');
+  assert.ok(docs!.value.length <= EMBED_FIELD_VALUE_MAX);
+});
+
+test('playbook show surfaces a friendly error when load fails', async () => {
+  const { maestro } = await import('../services/maestro');
+  mock.method(maestro, 'showPlaybook', async () => {
+    throw new Error('not found');
+  });
+
+  const i = makeInteraction('show', { playbook: 'pb-missing' });
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  const reply = i.editReply.mock.calls[0].arguments[0];
+  assert.equal(typeof reply, 'string');
+  assert.ok((reply as string).includes('Could not load playbook'));
+});

--- a/src/cli/lib.ts
+++ b/src/cli/lib.ts
@@ -1,0 +1,78 @@
+import http from 'http';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface SendApiPayload {
+  agentId: string;
+  message: string;
+  mention?: boolean;
+}
+
+export interface SendApiResult {
+  success: boolean;
+  channelId?: string;
+  error?: string;
+}
+
+export const DEFAULT_PORT = 3457;
+
+export function postToSendApi(payload: SendApiPayload, port: number): Promise<SendApiResult> {
+  const body = JSON.stringify(payload);
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/api/send',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let chunks = '';
+        res.on('data', (c) => (chunks += c));
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(chunks) as SendApiResult);
+          } catch {
+            reject(new Error('Invalid response from bot'));
+          }
+        });
+      },
+    );
+
+    req.on('error', (err) => {
+      if ((err as NodeJS.ErrnoException).code === 'ECONNREFUSED') {
+        reject(new Error('Bot is not running or API server is not started'));
+      } else {
+        reject(err);
+      }
+    });
+
+    req.write(body);
+    req.end();
+  });
+}
+
+export async function runMaestroCli(args: string[], timeoutMs = 10_000): Promise<string> {
+  const { stdout } = await execFileAsync('maestro-cli', args, {
+    timeout: timeoutMs,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return stdout.trim();
+}
+
+export function fail(message: string, code = 1): never {
+  console.error(`Error: ${message}`);
+  process.exit(code);
+}
+
+export function ok(result: SendApiResult): never {
+  console.log(JSON.stringify(result));
+  process.exit(result.success ? 0 : 1);
+}

--- a/src/cli/lib.ts
+++ b/src/cli/lib.ts
@@ -17,11 +17,23 @@ export interface SendApiResult {
 }
 
 export const DEFAULT_PORT = 3457;
+export const DEFAULT_REQUEST_TIMEOUT_MS = 5000;
 
-export function postToSendApi(payload: SendApiPayload, port: number): Promise<SendApiResult> {
+export function postToSendApi(
+  payload: SendApiPayload,
+  port: number,
+  timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS,
+): Promise<SendApiResult> {
   const body = JSON.stringify(payload);
 
   return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+
     const req = http.request(
       {
         hostname: '127.0.0.1',
@@ -37,26 +49,52 @@ export function postToSendApi(payload: SendApiPayload, port: number): Promise<Se
         let chunks = '';
         res.on('data', (c) => (chunks += c));
         res.on('end', () => {
-          try {
-            resolve(JSON.parse(chunks) as SendApiResult);
-          } catch {
-            reject(new Error('Invalid response from bot'));
-          }
+          settle(() => {
+            try {
+              resolve(JSON.parse(chunks) as SendApiResult);
+            } catch {
+              reject(new Error('Invalid response from bot'));
+            }
+          });
         });
       },
     );
 
+    req.setTimeout(timeoutMs, () => {
+      const err = new Error(`Request to bot timed out after ${timeoutMs}ms`);
+      req.destroy(err);
+      settle(() => reject(err));
+    });
+
     req.on('error', (err) => {
-      if ((err as NodeJS.ErrnoException).code === 'ECONNREFUSED') {
-        reject(new Error('Bot is not running or API server is not started'));
-      } else {
-        reject(err);
-      }
+      settle(() => {
+        if ((err as NodeJS.ErrnoException).code === 'ECONNREFUSED') {
+          reject(new Error('Bot is not running or API server is not started'));
+        } else {
+          reject(err);
+        }
+      });
     });
 
     req.write(body);
     req.end();
   });
+}
+
+/**
+ * Strictly parse a `--port` flag value into a valid TCP port number.
+ * Throws an `Error` if the value is missing/blank or not an integer in 1..65535.
+ */
+export function parsePort(raw: string | undefined, fallback: number = DEFAULT_PORT): number {
+  if (raw === undefined) return fallback;
+  if (!/^\d+$/.test(raw)) {
+    throw new Error('--port must be an integer between 1 and 65535');
+  }
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error('--port must be an integer between 1 and 65535');
+  }
+  return port;
 }
 
 export async function runMaestroCli(args: string[], timeoutMs = 10_000): Promise<string> {

--- a/src/cli/maestro-discord.ts
+++ b/src/cli/maestro-discord.ts
@@ -1,95 +1,50 @@
 #!/usr/bin/env node
-import http from 'http';
+import { runNotify, notifyUsage } from './verbs/notify';
+import { runSend, sendUsage } from './verbs/send';
+import { runStatus, statusUsage } from './verbs/status';
 
-function printUsage() {
-  console.log(`Usage: maestro-discord --agent <id> --message <text> [--mention] [--port <number>]
+const ROOT_USAGE = `Usage: maestro-discord <verb> [options]
 
-Options:
-  --agent    Maestro agent ID (required)
-  --message  Message text to send (required)
-  --mention  Mention users in the Discord channel
-  --port     API port (default: 3457)
-  --help     Show this help`);
+Verbs:
+  send      Send a message to an agent's Discord channel
+  notify    Post a styled toast/flash notification to an agent's channel
+  status    Post the agent's current status (cwd, usage, tokens) to its channel
+
+Run 'maestro-discord <verb> --help' for verb-specific options.`;
+
+function printRootHelp(): void {
+  console.log(ROOT_USAGE);
+  console.log('\n--- send ---\n' + sendUsage);
+  console.log('\n--- notify ---\n' + notifyUsage);
+  console.log('\n--- status ---\n' + statusUsage);
 }
 
-let agentId = '';
-let message = '';
-let mention = false;
-let port = 3457;
+async function main(): Promise<void> {
+  const [verb, ...rest] = process.argv.slice(2);
 
-const args = process.argv.slice(2);
-for (let i = 0; i < args.length; i++) {
-  switch (args[i]) {
-    case '--agent':
-      agentId = args[++i] || '';
-      break;
-    case '--message':
-      message = args[++i] || '';
-      break;
-    case '--mention':
-      mention = true;
-      break;
-    case '--port':
-      port = parseInt(args[++i] || '3457', 10);
-      break;
-    case '--help':
-      printUsage();
-      process.exit(0);
-      break;
+  if (!verb || verb === '--help' || verb === '-h') {
+    printRootHelp();
+    process.exit(verb ? 0 : 1);
+  }
+
+  switch (verb) {
+    case 'send':
+      await runSend(rest);
+      return;
+    case 'notify':
+      await runNotify(rest);
+      return;
+    case 'status':
+      await runStatus(rest);
+      return;
     default:
-      console.error(`Unknown flag: ${args[i]}`);
+      console.error(`Unknown verb: ${verb}\n`);
+      console.error(ROOT_USAGE);
       process.exit(1);
   }
 }
 
-if (!agentId || !message) {
-  console.error('Error: --agent and --message are required\n');
-  printUsage();
-  process.exit(1);
-}
-
-const payload = JSON.stringify({ agentId, message, mention });
-
-const req = http.request(
-  {
-    hostname: '127.0.0.1',
-    port,
-    path: '/api/send',
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Content-Length': Buffer.byteLength(payload),
-    },
-  },
-  (res) => {
-    let body = '';
-    res.on('data', (chunk) => (body += chunk));
-    res.on('end', () => {
-      try {
-        const result = JSON.parse(body);
-        if (result.success) {
-          console.log(JSON.stringify(result));
-          process.exit(0);
-        } else {
-          console.error(JSON.stringify(result));
-          process.exit(1);
-        }
-      } catch {
-        console.error('Invalid response from bot');
-        process.exit(1);
-      }
-    });
-  },
-);
-
-req.on('error', (err) => {
-  if ((err as NodeJS.ErrnoException).code === 'ECONNREFUSED') {
-    console.error('Error: Bot is not running or API server is not started');
-  } else {
-    console.error(`Error: ${err.message}`);
-  }
+main().catch((err) => {
+  console.error(`Error: ${(err as Error).message}`);
   process.exit(1);
 });
-
-req.write(payload);
-req.end();

--- a/src/cli/verbs/notify.ts
+++ b/src/cli/verbs/notify.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from 'node:util';
-import { DEFAULT_PORT, fail, ok, postToSendApi } from '../lib';
+import { DEFAULT_PORT, fail, ok, parsePort, postToSendApi } from '../lib';
 
 export const notifyUsage = `Usage: maestro-discord notify <toast|flash> [options]
 
@@ -76,8 +76,12 @@ export async function runNotify(argv: string[]): Promise<void> {
   const agentId = parsed.values.agent;
   if (!agentId) fail('--agent is required');
 
-  const port = parsed.values.port ? parseInt(parsed.values.port, 10) : DEFAULT_PORT;
-  if (Number.isNaN(port)) fail('--port must be a number');
+  let port: number;
+  try {
+    port = parsePort(parsed.values.port);
+  } catch (err) {
+    fail((err as Error).message);
+  }
 
   let content: string;
   if (sub === 'toast') {

--- a/src/cli/verbs/notify.ts
+++ b/src/cli/verbs/notify.ts
@@ -1,0 +1,104 @@
+import { parseArgs } from 'node:util';
+import { DEFAULT_PORT, fail, ok, postToSendApi } from '../lib';
+
+export const notifyUsage = `Usage: maestro-discord notify <toast|flash> [options]
+
+Post a styled notification message to an agent's Discord channel. Color maps
+to a leading emoji so the alert stands out from regular messages.
+
+Subcommands:
+  toast   --agent <id> --title <t> --message <m> [--color <c>]
+  flash   --agent <id> --message <m> [--detail <d>] [--color <c>]
+
+Options:
+  -a, --agent <id>      Maestro agent ID (required)
+  -t, --title <text>    Title line (toast only, required)
+  -m, --message <text>  Body text (required)
+  -D, --detail <text>   Second line (flash only, optional)
+  -c, --color <color>   green | yellow | orange | red | theme (default: theme)
+      --mention         Mention the user set in DISCORD_MENTION_USER_ID
+  -p, --port <number>   API port (default: ${DEFAULT_PORT})
+  -h, --help            Show this help`;
+
+const COLOR_EMOJI: Record<string, string> = {
+  green: '🟢',
+  yellow: '🟡',
+  orange: '🟠',
+  red: '🔴',
+  theme: '🔔',
+};
+
+function emojiFor(color: string | undefined, fallback: string): string {
+  if (!color) return fallback;
+  const e = COLOR_EMOJI[color];
+  if (!e) fail(`--color must be one of: ${Object.keys(COLOR_EMOJI).join(', ')}`);
+  return color === 'theme' ? fallback : e;
+}
+
+export async function runNotify(argv: string[]): Promise<void> {
+  const [sub, ...rest] = argv;
+
+  if (!sub || sub === '--help' || sub === '-h') {
+    console.log(notifyUsage);
+    process.exit(sub ? 0 : 1);
+  }
+
+  if (sub !== 'toast' && sub !== 'flash') {
+    fail(`Unknown notify subcommand: ${sub}. Expected 'toast' or 'flash'.`);
+  }
+
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: rest,
+      options: {
+        agent: { type: 'string', short: 'a' },
+        title: { type: 'string', short: 't' },
+        message: { type: 'string', short: 'm' },
+        detail: { type: 'string', short: 'D' },
+        color: { type: 'string', short: 'c' },
+        mention: { type: 'boolean', default: false },
+        port: { type: 'string', short: 'p' },
+        help: { type: 'boolean', short: 'h', default: false },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+  } catch (err) {
+    fail((err as Error).message);
+  }
+
+  if (parsed.values.help) {
+    console.log(notifyUsage);
+    process.exit(0);
+  }
+
+  const agentId = parsed.values.agent;
+  if (!agentId) fail('--agent is required');
+
+  const port = parsed.values.port ? parseInt(parsed.values.port, 10) : DEFAULT_PORT;
+  if (Number.isNaN(port)) fail('--port must be a number');
+
+  let content: string;
+  if (sub === 'toast') {
+    if (!parsed.values.title) fail('toast requires --title');
+    if (!parsed.values.message) fail('toast requires --message');
+    const icon = emojiFor(parsed.values.color, '🔔');
+    content = `${icon} **${parsed.values.title}**\n${parsed.values.message}`;
+  } else {
+    if (!parsed.values.message) fail('flash requires --message');
+    const icon = emojiFor(parsed.values.color, '⚡');
+    content = `${icon} ${parsed.values.message}`;
+    if (parsed.values.detail) content += `\n${parsed.values.detail}`;
+  }
+
+  try {
+    const result = await postToSendApi(
+      { agentId, message: content, mention: parsed.values.mention },
+      port,
+    );
+    ok(result);
+  } catch (err) {
+    fail((err as Error).message);
+  }
+}

--- a/src/cli/verbs/send.ts
+++ b/src/cli/verbs/send.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from 'node:util';
-import { DEFAULT_PORT, fail, ok, postToSendApi } from '../lib';
+import { DEFAULT_PORT, fail, ok, parsePort, postToSendApi } from '../lib';
 
 export const sendUsage = `Usage: maestro-discord send --agent <id> --message <text> [--mention] [--port <number>]
 
@@ -44,8 +44,12 @@ export async function runSend(argv: string[]): Promise<void> {
     fail('--agent and --message are required');
   }
 
-  const port = parsed.values.port ? parseInt(parsed.values.port, 10) : DEFAULT_PORT;
-  if (Number.isNaN(port)) fail('--port must be a number');
+  let port: number;
+  try {
+    port = parsePort(parsed.values.port);
+  } catch (err) {
+    fail((err as Error).message);
+  }
 
   try {
     const result = await postToSendApi(

--- a/src/cli/verbs/send.ts
+++ b/src/cli/verbs/send.ts
@@ -1,0 +1,59 @@
+import { parseArgs } from 'node:util';
+import { DEFAULT_PORT, fail, ok, postToSendApi } from '../lib';
+
+export const sendUsage = `Usage: maestro-discord send --agent <id> --message <text> [--mention] [--port <number>]
+
+Send a message to an agent's Discord channel (auto-creates channel if needed).
+
+Options:
+  -a, --agent <id>      Maestro agent ID (required)
+  -m, --message <text>  Message text to send (required)
+      --mention         Mention the user set in DISCORD_MENTION_USER_ID
+  -p, --port <number>   API port (default: ${DEFAULT_PORT})
+  -h, --help            Show this help`;
+
+export async function runSend(argv: string[]): Promise<void> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      options: {
+        agent: { type: 'string', short: 'a' },
+        message: { type: 'string', short: 'm' },
+        mention: { type: 'boolean', default: false },
+        port: { type: 'string', short: 'p' },
+        help: { type: 'boolean', short: 'h', default: false },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+  } catch (err) {
+    fail((err as Error).message);
+  }
+
+  if (parsed.values.help) {
+    console.log(sendUsage);
+    process.exit(0);
+  }
+
+  const agentId = parsed.values.agent;
+  const message = parsed.values.message;
+
+  if (!agentId || !message) {
+    console.error(sendUsage);
+    fail('--agent and --message are required');
+  }
+
+  const port = parsed.values.port ? parseInt(parsed.values.port, 10) : DEFAULT_PORT;
+  if (Number.isNaN(port)) fail('--port must be a number');
+
+  try {
+    const result = await postToSendApi(
+      { agentId, message, mention: parsed.values.mention },
+      port,
+    );
+    ok(result);
+  } catch (err) {
+    fail((err as Error).message);
+  }
+}

--- a/src/cli/verbs/status.ts
+++ b/src/cli/verbs/status.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from 'node:util';
-import { DEFAULT_PORT, fail, ok, postToSendApi, runMaestroCli } from '../lib';
+import { DEFAULT_PORT, fail, ok, parsePort, postToSendApi, runMaestroCli } from '../lib';
 
 export const statusUsage = `Usage: maestro-discord status --agent <id> [--port <number>]
 
@@ -82,15 +82,25 @@ export async function runStatus(argv: string[]): Promise<void> {
     fail('--agent is required');
   }
 
-  const port = parsed.values.port ? parseInt(parsed.values.port, 10) : DEFAULT_PORT;
-  if (Number.isNaN(port)) fail('--port must be a number');
+  let port: number;
+  try {
+    port = parsePort(parsed.values.port);
+  } catch (err) {
+    fail((err as Error).message);
+  }
+
+  let raw: string;
+  try {
+    raw = await runMaestroCli(['show', 'agent', agentId, '--json']);
+  } catch (err) {
+    fail(`maestro-cli show agent failed: ${(err as Error).message}`);
+  }
 
   let detail: AgentDetail;
   try {
-    const raw = await runMaestroCli(['show', 'agent', agentId, '--json']);
     detail = JSON.parse(raw) as AgentDetail;
   } catch (err) {
-    fail(`maestro-cli show agent failed: ${(err as Error).message}`);
+    fail(`Invalid JSON from maestro-cli show agent: ${(err as Error).message}`);
   }
 
   try {

--- a/src/cli/verbs/status.ts
+++ b/src/cli/verbs/status.ts
@@ -1,0 +1,105 @@
+import { parseArgs } from 'node:util';
+import { DEFAULT_PORT, fail, ok, postToSendApi, runMaestroCli } from '../lib';
+
+export const statusUsage = `Usage: maestro-discord status --agent <id> [--port <number>]
+
+Fetch agent details from maestro-cli and post a formatted status summary to
+the agent's Discord channel.
+
+Options:
+  -a, --agent <id>     Maestro agent ID (required)
+      --mention        Mention the user set in DISCORD_MENTION_USER_ID
+  -p, --port <number>  API port (default: ${DEFAULT_PORT})
+  -h, --help           Show this help`;
+
+interface AgentDetail {
+  id?: string;
+  name?: string;
+  toolType?: string;
+  cwd?: string;
+  status?: string;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalCostUsd?: number;
+    contextUsagePercent?: number;
+  };
+  [key: string]: unknown;
+}
+
+function formatStatus(detail: AgentDetail): string {
+  const lines: string[] = [];
+  const name = detail.name ?? detail.id ?? 'unknown';
+  lines.push(`📊 **Status: ${name}**`);
+  if (detail.toolType) lines.push(`Tool: \`${detail.toolType}\``);
+  if (detail.cwd) lines.push(`Cwd: \`${detail.cwd}\``);
+  if (detail.status) lines.push(`State: ${detail.status}`);
+
+  const u = detail.usage;
+  if (u) {
+    const parts: string[] = [];
+    if (typeof u.contextUsagePercent === 'number') {
+      parts.push(`context ${u.contextUsagePercent.toFixed(1)}%`);
+    }
+    if (typeof u.totalCostUsd === 'number') {
+      parts.push(`$${u.totalCostUsd.toFixed(4)}`);
+    }
+    if (typeof u.inputTokens === 'number' && typeof u.outputTokens === 'number') {
+      parts.push(`${u.inputTokens}↓ ${u.outputTokens}↑ tokens`);
+    }
+    if (parts.length) lines.push(`Usage: ${parts.join(' · ')}`);
+  }
+
+  return lines.join('\n');
+}
+
+export async function runStatus(argv: string[]): Promise<void> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      options: {
+        agent: { type: 'string', short: 'a' },
+        mention: { type: 'boolean', default: false },
+        port: { type: 'string', short: 'p' },
+        help: { type: 'boolean', short: 'h', default: false },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+  } catch (err) {
+    fail((err as Error).message);
+  }
+
+  if (parsed.values.help) {
+    console.log(statusUsage);
+    process.exit(0);
+  }
+
+  const agentId = parsed.values.agent;
+  if (!agentId) {
+    console.error(statusUsage);
+    fail('--agent is required');
+  }
+
+  const port = parsed.values.port ? parseInt(parsed.values.port, 10) : DEFAULT_PORT;
+  if (Number.isNaN(port)) fail('--port must be a number');
+
+  let detail: AgentDetail;
+  try {
+    const raw = await runMaestroCli(['show', 'agent', agentId, '--json']);
+    detail = JSON.parse(raw) as AgentDetail;
+  } catch (err) {
+    fail(`maestro-cli show agent failed: ${(err as Error).message}`);
+  }
+
+  try {
+    const result = await postToSendApi(
+      { agentId, message: formatStatus(detail), mention: parsed.values.mention },
+      port,
+    );
+    ok(result);
+  } catch (err) {
+    fail((err as Error).message);
+  }
+}

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -36,6 +36,18 @@ export const data = new SlashCommandBuilder()
       ),
   )
   .addSubcommand((sub) =>
+    sub
+      .setName('show')
+      .setDescription("Show an agent's details, stats, and recent activity")
+      .addStringOption((opt) =>
+        opt
+          .setName('agent')
+          .setDescription('Select an agent')
+          .setRequired(true)
+          .setAutocomplete(true),
+      ),
+  )
+  .addSubcommand((sub) =>
     sub.setName('disconnect').setDescription('Remove this agent channel (deletes the channel)'),
   )
   .addSubcommand((sub) =>
@@ -86,6 +98,8 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     await handleList(interaction);
   } else if (sub === 'new') {
     await handleNew(interaction);
+  } else if (sub === 'show') {
+    await handleShow(interaction);
   } else if (sub === 'disconnect') {
     await handleDisconnect(interaction);
   } else if (sub === 'readonly') {
@@ -192,6 +206,72 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
       `Type any message here and it will be sent to this agent.\n` +
       `-# Agent: \`${agent.id}\` • ${agent.toolType} • \`${agent.cwd}\``,
   );
+}
+
+async function handleShow(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.deferReply({ ephemeral: true });
+
+  const agentId = interaction.options.getString('agent', true);
+
+  let detail;
+  try {
+    detail = await maestro.showAgent(agentId);
+  } catch (err) {
+    await interaction.editReply(`❌ Could not load agent: ${(err as Error).message}`);
+    return;
+  }
+
+  const embed = new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle(detail.name)
+    .addFields(
+      { name: 'ID', value: `\`${detail.id}\``, inline: false },
+      { name: 'Tool', value: detail.toolType, inline: true },
+      { name: 'Cwd', value: `\`${detail.cwd}\``, inline: false },
+    );
+
+  if (detail.groupName) {
+    embed.addFields({ name: 'Group', value: detail.groupName, inline: true });
+  }
+
+  const stats = detail.stats;
+  if (stats) {
+    const statLines: string[] = [];
+    if (typeof stats.historyEntries === 'number') {
+      const ok = stats.successCount ?? 0;
+      const fail = stats.failureCount ?? 0;
+      statLines.push(`History: ${stats.historyEntries} entries (${ok} ok · ${fail} failed)`);
+    }
+    if (typeof stats.totalInputTokens === 'number' || typeof stats.totalOutputTokens === 'number') {
+      statLines.push(
+        `Tokens: ${stats.totalInputTokens ?? 0}↓ ${stats.totalOutputTokens ?? 0}↑`,
+      );
+    }
+    if (typeof stats.totalCost === 'number' && stats.totalCost > 0) {
+      statLines.push(`Cost: $${stats.totalCost.toFixed(4)}`);
+    }
+    if (typeof stats.totalElapsedMs === 'number' && stats.totalElapsedMs > 0) {
+      statLines.push(`Total elapsed: ${(stats.totalElapsedMs / 1000).toFixed(1)}s`);
+    }
+    if (statLines.length) {
+      embed.addFields({ name: 'Stats', value: statLines.join('\n') });
+    }
+  }
+
+  if (detail.recentHistory && detail.recentHistory.length > 0) {
+    const recent = detail.recentHistory
+      .slice(0, 5)
+      .map((h) => {
+        const when = new Date(h.timestamp).toLocaleString();
+        const status = h.success === false ? '⚠️' : '•';
+        const summary = (h.summary ?? '').slice(0, 90);
+        return `${status} ${when} — ${summary}`;
+      })
+      .join('\n');
+    embed.addFields({ name: 'Recent activity', value: recent });
+  }
+
+  await interaction.editReply({ embeds: [embed] });
 }
 
 async function handleReadonly(interaction: ChatInputCommandInteraction): Promise<void> {

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -4,7 +4,6 @@ import {
   SlashCommandBuilder,
   EmbedBuilder,
   ChannelType,
-  TextChannel,
 } from 'discord.js';
 import { maestro } from '../services/maestro';
 import { channelDb, threadDb } from '../db';
@@ -203,7 +202,7 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
     );
     return;
   }
-  const channel = newChannel as TextChannel;
+  const channel = newChannel;
 
   channelDb.register(channel.id, guild.id, agent.id, agent.name);
 

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -9,7 +9,7 @@ import {
 import { maestro } from '../services/maestro';
 import { channelDb, threadDb } from '../db';
 import { cleanupAgentFiles } from '../utils/attachments';
-import { clampFieldValue } from '../utils/embed';
+import { clampFieldValue, clampTitle } from '../utils/embed';
 import { config } from '../config';
 
 function missingBotScopeMessage(): string {
@@ -187,13 +187,23 @@ async function handleNew(interaction: ChatInputCommandInteraction): Promise<void
     });
   }
 
-  const channelName = `agent-${agent.name.toLowerCase().replace(/[^a-z0-9-]/g, '-')}`;
-  const channel = (await guild.channels.create({
+  const channelName = `agent-${agent.name.toLowerCase().replace(/[^a-z0-9-]/g, '-')}`.slice(
+    0,
+    100,
+  );
+  const newChannel = await guild.channels.create({
     name: channelName,
     type: ChannelType.GuildText,
     parent: category.id,
     topic: `Maestro agent: ${agent.name} (${agent.id}) | ${agent.toolType} | ${agent.cwd}`,
-  })) as TextChannel;
+  });
+  if (!newChannel.isSendable()) {
+    await interaction.editReply(
+      '❌ Failed to create a sendable channel for the agent. Check bot permissions in this server.',
+    );
+    return;
+  }
+  const channel = newChannel as TextChannel;
 
   channelDb.register(channel.id, guild.id, agent.id, agent.name);
 
@@ -224,7 +234,7 @@ async function handleShow(interaction: ChatInputCommandInteraction): Promise<voi
 
   const embed = new EmbedBuilder()
     .setColor(0x5865f2)
-    .setTitle(detail.name)
+    .setTitle(clampTitle(detail.name))
     .addFields(
       { name: 'ID', value: `\`${detail.id}\``, inline: false },
       { name: 'Tool', value: detail.toolType, inline: true },
@@ -232,7 +242,7 @@ async function handleShow(interaction: ChatInputCommandInteraction): Promise<voi
     );
 
   if (detail.groupName) {
-    embed.addFields({ name: 'Group', value: detail.groupName, inline: true });
+    embed.addFields({ name: 'Group', value: clampFieldValue(detail.groupName), inline: true });
   }
 
   const stats = detail.stats;

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -9,6 +9,7 @@ import {
 import { maestro } from '../services/maestro';
 import { channelDb, threadDb } from '../db';
 import { cleanupAgentFiles } from '../utils/attachments';
+import { clampFieldValue } from '../utils/embed';
 import { config } from '../config';
 
 function missingBotScopeMessage(): string {
@@ -227,7 +228,7 @@ async function handleShow(interaction: ChatInputCommandInteraction): Promise<voi
     .addFields(
       { name: 'ID', value: `\`${detail.id}\``, inline: false },
       { name: 'Tool', value: detail.toolType, inline: true },
-      { name: 'Cwd', value: `\`${detail.cwd}\``, inline: false },
+      { name: 'Cwd', value: clampFieldValue(`\`${detail.cwd}\``), inline: false },
     );
 
   if (detail.groupName) {
@@ -254,7 +255,7 @@ async function handleShow(interaction: ChatInputCommandInteraction): Promise<voi
       statLines.push(`Total elapsed: ${(stats.totalElapsedMs / 1000).toFixed(1)}s`);
     }
     if (statLines.length) {
-      embed.addFields({ name: 'Stats', value: statLines.join('\n') });
+      embed.addFields({ name: 'Stats', value: clampFieldValue(statLines.join('\n')) });
     }
   }
 
@@ -268,7 +269,7 @@ async function handleShow(interaction: ChatInputCommandInteraction): Promise<voi
         return `${status} ${when} — ${summary}`;
       })
       .join('\n');
-    embed.addFields({ name: 'Recent activity', value: recent });
+    embed.addFields({ name: 'Recent activity', value: clampFieldValue(recent) });
   }
 
   await interaction.editReply({ embeds: [embed] });

--- a/src/commands/auto-run.ts
+++ b/src/commands/auto-run.ts
@@ -51,6 +51,22 @@ async function getAgentFolder(agentId: string): Promise<string | null> {
   }
 }
 
+/**
+ * Resolve `doc` (a user-supplied filename, relative path, or absolute path)
+ * to a normalized path strictly contained within `folder`. Returns null when
+ * the resolved path escapes the folder (e.g. `..` traversal or an absolute
+ * path pointing elsewhere) — callers must reject in that case.
+ */
+export function resolveContainedDocPath(folder: string, doc: string): string | null {
+  const folderResolved = path.resolve(folder);
+  const candidate = path.isAbsolute(doc) ? doc : path.join(folderResolved, doc);
+  const resolved = path.resolve(candidate);
+  if (resolved === folderResolved) return null; // doc must be a file inside, not the folder itself
+  const prefix = folderResolved.endsWith(path.sep) ? folderResolved : folderResolved + path.sep;
+  if (!resolved.startsWith(prefix)) return null;
+  return resolved;
+}
+
 export async function autocomplete(interaction: AutocompleteInteraction): Promise<void> {
   const focused = interaction.options.getFocused(true);
   if (focused.name !== 'doc') return interaction.respond([]);
@@ -63,10 +79,16 @@ export async function autocomplete(interaction: AutocompleteInteraction): Promis
 
   let entries: string[];
   try {
-    const dirents = await fs.readdir(folder, { withFileTypes: true });
+    // Recursive so docs in subfolders (e.g. `subdir/plan.md`) are discoverable
+    // — execution already supports those relative paths. Use forward slashes
+    // for the value so the result is portable.
+    const dirents = await fs.readdir(folder, { withFileTypes: true, recursive: true });
     entries = dirents
       .filter((d) => d.isFile() && d.name.toLowerCase().endsWith('.md'))
-      .map((d) => d.name);
+      .map((d) => {
+        const abs = path.join(d.parentPath, d.name);
+        return path.relative(folder, abs).split(path.sep).join('/');
+      });
   } catch {
     return interaction.respond([]);
   }
@@ -76,7 +98,7 @@ export async function autocomplete(interaction: AutocompleteInteraction): Promis
     entries
       .filter((n) => n.toLowerCase().includes(value))
       .slice(0, 25)
-      .map((n) => ({ name: n.slice(0, 100), value: n })),
+      .map((n) => ({ name: n.slice(0, 100), value: n.slice(0, 100) })),
   );
 }
 
@@ -101,11 +123,22 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
   const resetOnCompletion =
     interaction.options.getBoolean('reset_on_completion') ?? undefined;
 
-  // Resolve any relative path (filename or subpath) against the agent's Auto Run folder.
-  let docPath = doc;
-  if (!path.isAbsolute(doc)) {
-    const folder = await getAgentFolder(channelInfo.agent_id);
-    if (folder) docPath = path.join(folder, doc);
+  // The slash command's contract is "one of this agent's Auto Run documents",
+  // so we must enforce containment within the agent's Auto Run folder. Reject
+  // absolute paths pointing elsewhere, and `..` traversal that escapes.
+  const folder = await getAgentFolder(channelInfo.agent_id);
+  if (!folder) {
+    await interaction.editReply(
+      "❌ Could not determine this agent's Auto Run folder. Open the agent in Maestro and configure one, then try again.",
+    );
+    return;
+  }
+  const docPath = resolveContainedDocPath(folder, doc);
+  if (!docPath) {
+    await interaction.editReply(
+      "❌ Document must live inside this agent's Auto Run folder. Use a filename or relative subpath (no `..` traversal or absolute paths outside the folder).",
+    );
+    return;
   }
 
   try {

--- a/src/commands/auto-run.ts
+++ b/src/commands/auto-run.ts
@@ -1,0 +1,136 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import {
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  SlashCommandBuilder,
+} from 'discord.js';
+import { channelDb } from '../db';
+import { maestro } from '../services/maestro';
+
+export const data = new SlashCommandBuilder()
+  .setName('auto-run')
+  .setDescription("Launch one of this agent's Auto Run documents")
+  .addSubcommand((sub) =>
+    sub
+      .setName('start')
+      .setDescription("Configure and launch an Auto Run for this channel's agent")
+      .addStringOption((opt) =>
+        opt
+          .setName('doc')
+          .setDescription('Auto Run document (filename or path)')
+          .setRequired(true)
+          .setAutocomplete(true),
+      )
+      .addStringOption((opt) =>
+        opt.setName('prompt').setDescription('Override the default prompt').setRequired(false),
+      )
+      .addIntegerOption((opt) =>
+        opt
+          .setName('max_loops')
+          .setDescription('Loop the run up to N times')
+          .setMinValue(1)
+          .setMaxValue(50)
+          .setRequired(false),
+      )
+      .addBooleanOption((opt) =>
+        opt
+          .setName('reset_on_completion')
+          .setDescription('Reset all task checkboxes when the run finishes')
+          .setRequired(false),
+      ),
+  );
+
+async function getAgentFolder(agentId: string): Promise<string | null> {
+  try {
+    const agents = await maestro.listAgents();
+    const agent = agents.find((a) => a.id === agentId);
+    const folder = agent && (agent as { autoRunFolderPath?: unknown }).autoRunFolderPath;
+    return typeof folder === 'string' ? folder : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function autocomplete(interaction: AutocompleteInteraction): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  if (focused.name !== 'doc') return interaction.respond([]);
+
+  const channelInfo = channelDb.get(interaction.channelId);
+  if (!channelInfo) return interaction.respond([]);
+
+  const folder = await getAgentFolder(channelInfo.agent_id);
+  if (!folder) return interaction.respond([]);
+
+  let entries: string[];
+  try {
+    const dirents = await fs.readdir(folder, { withFileTypes: true });
+    entries = dirents
+      .filter((d) => d.isFile() && d.name.toLowerCase().endsWith('.md'))
+      .map((d) => d.name);
+  } catch {
+    return interaction.respond([]);
+  }
+
+  const value = focused.value.toLowerCase();
+  await interaction.respond(
+    entries
+      .filter((n) => n.toLowerCase().includes(value))
+      .slice(0, 25)
+      .map((n) => ({ name: n.slice(0, 100), value: n })),
+  );
+}
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  const sub = interaction.options.getSubcommand();
+  if (sub !== 'start') return;
+
+  const channelInfo = channelDb.get(interaction.channelId);
+  if (!channelInfo) {
+    await interaction.reply({
+      content: '❌ This channel is not connected to an agent. Use `/agents new` first.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await interaction.deferReply();
+
+  const doc = interaction.options.getString('doc', true);
+  const prompt = interaction.options.getString('prompt') ?? undefined;
+  const maxLoops = interaction.options.getInteger('max_loops') ?? undefined;
+  const resetOnCompletion =
+    interaction.options.getBoolean('reset_on_completion') ?? undefined;
+
+  // If the user typed a bare filename, resolve it against the agent's Auto Run folder.
+  let docPath = doc;
+  if (!path.isAbsolute(doc) && !doc.includes('/')) {
+    const folder = await getAgentFolder(channelInfo.agent_id);
+    if (folder) docPath = path.join(folder, doc);
+  }
+
+  try {
+    await maestro.startAutoRun({
+      agentId: channelInfo.agent_id,
+      docs: [docPath],
+      prompt,
+      maxLoops,
+      resetOnCompletion,
+    });
+  } catch (err) {
+    await interaction.editReply(
+      `❌ Auto Run failed to launch: ${(err as Error).message.slice(0, 1500)}`,
+    );
+    return;
+  }
+
+  const lines: string[] = [
+    `▶️ Launched Auto Run for **${channelInfo.agent_name}** with \`${path.basename(docPath)}\`.`,
+  ];
+  if (maxLoops != null) lines.push(`Looping up to ${maxLoops} times.`);
+  if (prompt) lines.push('Custom prompt set.');
+  if (resetOnCompletion) lines.push('Tasks will reset on completion.');
+  lines.push('Watch the agent channel for progress.');
+
+  await interaction.editReply(lines.join('\n'));
+}

--- a/src/commands/auto-run.ts
+++ b/src/commands/auto-run.ts
@@ -43,9 +43,8 @@ export const data = new SlashCommandBuilder()
 
 async function getAgentFolder(agentId: string): Promise<string | null> {
   try {
-    const agents = await maestro.listAgents();
-    const agent = agents.find((a) => a.id === agentId);
-    const folder = agent && (agent as { autoRunFolderPath?: unknown }).autoRunFolderPath;
+    const agent = await maestro.showAgent(agentId);
+    const folder = agent.autoRunFolderPath;
     return typeof folder === 'string' ? folder : null;
   } catch {
     return null;
@@ -102,9 +101,9 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
   const resetOnCompletion =
     interaction.options.getBoolean('reset_on_completion') ?? undefined;
 
-  // If the user typed a bare filename, resolve it against the agent's Auto Run folder.
+  // Resolve any relative path (filename or subpath) against the agent's Auto Run folder.
   let docPath = doc;
-  if (!path.isAbsolute(doc) && !doc.includes('/')) {
+  if (!path.isAbsolute(doc)) {
     const folder = await getAgentFolder(channelInfo.agent_id);
     if (folder) docPath = path.join(folder, doc);
   }

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -1,0 +1,55 @@
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  SlashCommandBuilder,
+} from 'discord.js';
+import { channelDb } from '../db';
+import { maestro } from '../services/maestro';
+
+export const data = new SlashCommandBuilder()
+  .setName('gist')
+  .setDescription("Publish this agent's session transcript as a GitHub gist")
+  .addStringOption((opt) =>
+    opt.setName('description').setDescription('Optional gist description').setRequired(false),
+  )
+  .addBooleanOption((opt) =>
+    opt
+      .setName('public')
+      .setDescription('Make the gist public (default: private)')
+      .setRequired(false),
+  );
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  const channelInfo = channelDb.get(interaction.channelId);
+  if (!channelInfo) {
+    await interaction.reply({
+      content: '❌ This channel is not connected to an agent. Use `/agents new` first.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await interaction.deferReply();
+
+  const description = interaction.options.getString('description') ?? undefined;
+  const isPublic = interaction.options.getBoolean('public') ?? false;
+
+  let result;
+  try {
+    result = await maestro.createGist(channelInfo.agent_id, { description, isPublic });
+  } catch (err) {
+    await interaction.editReply(
+      `❌ Could not publish gist: ${(err as Error).message.slice(0, 1500)}`,
+    );
+    return;
+  }
+
+  const visibility = isPublic ? 'public' : 'private';
+  const embed = new EmbedBuilder()
+    .setColor(0x57f287)
+    .setTitle(`📎 Gist published — ${channelInfo.agent_name}`)
+    .setURL(result.url)
+    .setDescription(`[Open gist](${result.url})\nVisibility: **${visibility}**`);
+
+  await interaction.editReply({ embeds: [embed] });
+}

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -38,9 +38,8 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
   try {
     result = await maestro.createGist(channelInfo.agent_id, { description, isPublic });
   } catch (err) {
-    await interaction.editReply(
-      `❌ Could not publish gist: ${(err as Error).message.slice(0, 1500)}`,
-    );
+    const message = err instanceof Error ? err.message : String(err);
+    await interaction.editReply(`❌ Could not publish gist: ${message.slice(0, 1500)}`);
     return;
   }
 

--- a/src/commands/notes.ts
+++ b/src/commands/notes.ts
@@ -1,0 +1,156 @@
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  SlashCommandBuilder,
+} from 'discord.js';
+import { maestro } from '../services/maestro';
+
+export const data = new SlashCommandBuilder()
+  .setName('notes')
+  .setDescription("Director's Notes: AI synopsis or unified history across agents")
+  .addSubcommand((sub) =>
+    sub
+      .setName('synopsis')
+      .setDescription('AI-generated synopsis of recent activity (slow — runs the LLM)')
+      .addIntegerOption((opt) =>
+        opt
+          .setName('days')
+          .setDescription('Lookback period in days')
+          .setMinValue(1)
+          .setMaxValue(30)
+          .setRequired(false),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName('history')
+      .setDescription('Recent unified history entries')
+      .addIntegerOption((opt) =>
+        opt
+          .setName('days')
+          .setDescription('Lookback period in days')
+          .setMinValue(1)
+          .setMaxValue(30)
+          .setRequired(false),
+      )
+      .addIntegerOption((opt) =>
+        opt
+          .setName('limit')
+          .setDescription('Max entries to show (default 20)')
+          .setMinValue(1)
+          .setMaxValue(50)
+          .setRequired(false),
+      )
+      .addStringOption((opt) =>
+        opt
+          .setName('filter')
+          .setDescription('Entry type filter')
+          .setRequired(false)
+          .addChoices(
+            { name: 'auto', value: 'auto' },
+            { name: 'user', value: 'user' },
+            { name: 'cue', value: 'cue' },
+          ),
+      ),
+  );
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  const sub = interaction.options.getSubcommand();
+  if (sub === 'synopsis') return handleSynopsis(interaction);
+  if (sub === 'history') return handleHistory(interaction);
+}
+
+async function handleSynopsis(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.deferReply();
+
+  const days = interaction.options.getInteger('days') ?? undefined;
+
+  let result;
+  try {
+    result = await maestro.directorSynopsis({ days });
+  } catch (err) {
+    await interaction.editReply(
+      `❌ Synopsis failed: ${(err as Error).message.slice(0, 1500)}`,
+    );
+    return;
+  }
+
+  const text = result.markdown ?? result.synopsis ?? result.text ?? '_(empty synopsis)_';
+  const truncated = text.length > 4000 ? text.slice(0, 4000) + '\n\n_…truncated_' : text;
+
+  const embed = new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle(`🎬 Director's synopsis${days ? ` — last ${days}d` : ''}`)
+    .setDescription(truncated);
+
+  if (typeof result.entriesAnalyzed === 'number') {
+    embed.setFooter({
+      text: `Analyzed ${result.entriesAnalyzed} entries${
+        typeof result.daysCovered === 'number' ? ` over ${result.daysCovered}d` : ''
+      }`,
+    });
+  }
+
+  await interaction.editReply({ embeds: [embed] });
+}
+
+async function handleHistory(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.deferReply({ ephemeral: true });
+
+  const days = interaction.options.getInteger('days') ?? undefined;
+  const limit = interaction.options.getInteger('limit') ?? 20;
+  const filter = interaction.options.getString('filter') as
+    | 'auto'
+    | 'user'
+    | 'cue'
+    | null;
+
+  let entries;
+  try {
+    entries = await maestro.directorHistory({
+      days,
+      limit,
+      filter: filter ?? undefined,
+    });
+  } catch (err) {
+    await interaction.editReply(
+      `❌ History fetch failed: ${(err as Error).message.slice(0, 1500)}`,
+    );
+    return;
+  }
+
+  if (entries.length === 0) {
+    await interaction.editReply('No history entries in the requested window.');
+    return;
+  }
+
+  const lines = entries.map((e) => {
+    const when = e.timestamp ? new Date(e.timestamp).toLocaleString() : '—';
+    const type = e.type ?? '?';
+    const agent = e.agentName ? ` · ${e.agentName}` : '';
+    const status = e.success === false ? '⚠️' : '•';
+    const summary = (e.summary ?? '').slice(0, 100);
+    return `${status} \`${type}\` ${when}${agent}\n${summary}`;
+  });
+
+  const MAX_DESC = 4096;
+  let description = '';
+  let shown = 0;
+  for (const line of lines) {
+    const addition = description ? '\n\n' + line : line;
+    if (description.length + addition.length > MAX_DESC) break;
+    description += addition;
+    shown++;
+  }
+
+  const embed = new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle(`📜 Director history${days ? ` — last ${days}d` : ''}`)
+    .setDescription(description);
+
+  if (shown < entries.length) {
+    embed.setFooter({ text: `Showing ${shown} of ${entries.length}` });
+  }
+
+  await interaction.editReply({ embeds: [embed] });
+}

--- a/src/commands/playbook.ts
+++ b/src/commands/playbook.ts
@@ -5,7 +5,7 @@ import {
   SlashCommandBuilder,
 } from 'discord.js';
 import { maestro } from '../services/maestro';
-import { clampDescription, clampFieldValue } from '../utils/embed';
+import { clampDescription, clampFieldValue, clampTitle } from '../utils/embed';
 
 export const data = new SlashCommandBuilder()
   .setName('playbook')
@@ -156,7 +156,7 @@ async function handleShow(interaction: ChatInputCommandInteraction): Promise<voi
 
   const embed = new EmbedBuilder()
     .setColor(0x5865f2)
-    .setTitle(detail.name)
+    .setTitle(clampTitle(detail.name))
     .setDescription(clampDescription(detail.description || '_(no description)_'))
     .addFields(
       { name: 'ID', value: `\`${detail.id}\``, inline: true },
@@ -168,7 +168,7 @@ async function handleShow(interaction: ChatInputCommandInteraction): Promise<voi
     );
 
   if (detail.agentName) {
-    embed.addFields({ name: 'Agent', value: detail.agentName, inline: true });
+    embed.addFields({ name: 'Agent', value: clampFieldValue(detail.agentName), inline: true });
   }
   if (docLines.length) {
     embed.addFields({ name: 'Documents', value: clampFieldValue(docLines.join('\n')) });

--- a/src/commands/playbook.ts
+++ b/src/commands/playbook.ts
@@ -5,6 +5,7 @@ import {
   SlashCommandBuilder,
 } from 'discord.js';
 import { maestro } from '../services/maestro';
+import { clampDescription, clampFieldValue } from '../utils/embed';
 
 export const data = new SlashCommandBuilder()
   .setName('playbook')
@@ -156,7 +157,7 @@ async function handleShow(interaction: ChatInputCommandInteraction): Promise<voi
   const embed = new EmbedBuilder()
     .setColor(0x5865f2)
     .setTitle(detail.name)
-    .setDescription(detail.description || '_(no description)_')
+    .setDescription(clampDescription(detail.description || '_(no description)_'))
     .addFields(
       { name: 'ID', value: `\`${detail.id}\``, inline: true },
       {
@@ -170,7 +171,7 @@ async function handleShow(interaction: ChatInputCommandInteraction): Promise<voi
     embed.addFields({ name: 'Agent', value: detail.agentName, inline: true });
   }
   if (docLines.length) {
-    embed.addFields({ name: 'Documents', value: docLines.join('\n') });
+    embed.addFields({ name: 'Documents', value: clampFieldValue(docLines.join('\n')) });
   }
 
   await interaction.editReply({ embeds: [embed] });

--- a/src/commands/playbook.ts
+++ b/src/commands/playbook.ts
@@ -1,0 +1,226 @@
+import {
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  SlashCommandBuilder,
+} from 'discord.js';
+import { maestro } from '../services/maestro';
+
+export const data = new SlashCommandBuilder()
+  .setName('playbook')
+  .setDescription('Run and inspect Maestro playbooks')
+  .addSubcommand((sub) =>
+    sub
+      .setName('list')
+      .setDescription('List available playbooks')
+      .addStringOption((opt) =>
+        opt
+          .setName('agent')
+          .setDescription('Filter to one agent')
+          .setRequired(false)
+          .setAutocomplete(true),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName('show')
+      .setDescription('Show details for a playbook')
+      .addStringOption((opt) =>
+        opt
+          .setName('playbook')
+          .setDescription('Playbook to show')
+          .setRequired(true)
+          .setAutocomplete(true),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName('run')
+      .setDescription('Run a playbook and post the result here')
+      .addStringOption((opt) =>
+        opt
+          .setName('playbook')
+          .setDescription('Playbook to run')
+          .setRequired(true)
+          .setAutocomplete(true),
+      ),
+  );
+
+export async function autocomplete(interaction: AutocompleteInteraction): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  const value = focused.value.toLowerCase();
+
+  try {
+    if (focused.name === 'agent') {
+      const agents = await maestro.listAgents();
+      await interaction.respond(
+        agents
+          .filter(
+            (a) => a.name.toLowerCase().includes(value) || a.id.toLowerCase().includes(value),
+          )
+          .slice(0, 25)
+          .map((a) => ({ name: `${a.name} (${a.toolType})`, value: a.id })),
+      );
+      return;
+    }
+
+    if (focused.name === 'playbook') {
+      const playbooks = await maestro.listPlaybooks();
+      await interaction.respond(
+        playbooks
+          .filter(
+            (p) => p.name.toLowerCase().includes(value) || p.id.toLowerCase().includes(value),
+          )
+          .slice(0, 25)
+          .map((p) => ({
+            name: `${p.name}${p.agentName ? ` (${p.agentName})` : ''}`.slice(0, 100),
+            value: p.id,
+          })),
+      );
+      return;
+    }
+  } catch {
+    await interaction.respond([]);
+  }
+}
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  const sub = interaction.options.getSubcommand();
+  if (sub === 'list') return handleList(interaction);
+  if (sub === 'show') return handleShow(interaction);
+  if (sub === 'run') return handleRun(interaction);
+}
+
+async function handleList(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.deferReply({ ephemeral: true });
+
+  const agentId = interaction.options.getString('agent') ?? undefined;
+  const playbooks = await maestro.listPlaybooks(agentId);
+
+  if (playbooks.length === 0) {
+    await interaction.editReply(
+      agentId
+        ? 'No playbooks found for that agent.'
+        : 'No playbooks found. Create one in the Maestro app first.',
+    );
+    return;
+  }
+
+  const lines = playbooks.map((p) => {
+    const owner = p.agentName ? ` · ${p.agentName}` : '';
+    return `**${p.name}**${owner}\n\`${p.id}\` · ${p.documentCount} docs · ${p.taskCount} tasks`;
+  });
+
+  const MAX_DESC = 4096;
+  let description = '';
+  let shown = 0;
+  for (const line of lines) {
+    const addition = description ? '\n\n' + line : line;
+    if (description.length + addition.length > MAX_DESC) break;
+    description += addition;
+    shown++;
+  }
+
+  const embed = new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle('Playbooks')
+    .setDescription(description);
+
+  if (shown < playbooks.length) {
+    embed.setFooter({ text: `Showing ${shown} of ${playbooks.length}` });
+  }
+
+  await interaction.editReply({ embeds: [embed] });
+}
+
+async function handleShow(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.deferReply({ ephemeral: true });
+
+  const playbookId = interaction.options.getString('playbook', true);
+
+  let detail;
+  try {
+    detail = await maestro.showPlaybook(playbookId);
+  } catch (err) {
+    await interaction.editReply(`❌ Could not load playbook: ${(err as Error).message}`);
+    return;
+  }
+
+  const docLines = detail.documents
+    .slice(0, 15)
+    .map((d) => `• \`${d.path}\` — ${d.completedCount}/${d.taskCount} tasks`);
+  if (detail.documents.length > 15) {
+    docLines.push(`… and ${detail.documents.length - 15} more`);
+  }
+
+  const embed = new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle(detail.name)
+    .setDescription(detail.description || '_(no description)_')
+    .addFields(
+      { name: 'ID', value: `\`${detail.id}\``, inline: true },
+      {
+        name: 'Tasks',
+        value: `${detail.taskCount} (${detail.documentCount} docs)`,
+        inline: true,
+      },
+    );
+
+  if (detail.agentName) {
+    embed.addFields({ name: 'Agent', value: detail.agentName, inline: true });
+  }
+  if (docLines.length) {
+    embed.addFields({ name: 'Documents', value: docLines.join('\n') });
+  }
+
+  await interaction.editReply({ embeds: [embed] });
+}
+
+async function handleRun(interaction: ChatInputCommandInteraction): Promise<void> {
+  // Public reply — playbook runs are interesting to the channel
+  await interaction.deferReply();
+
+  const playbookId = interaction.options.getString('playbook', true);
+
+  let detail;
+  try {
+    detail = await maestro.showPlaybook(playbookId);
+  } catch {
+    detail = null;
+  }
+  const label = detail?.name ?? playbookId;
+
+  await interaction.editReply(`▶️ Running playbook **${label}**…`);
+
+  let event;
+  try {
+    event = await maestro.runPlaybook(playbookId);
+  } catch (err) {
+    await interaction.editReply(
+      `❌ Playbook **${label}** failed: ${(err as Error).message.slice(0, 1500)}`,
+    );
+    return;
+  }
+
+  const lines: string[] = [
+    event.success === false
+      ? `⚠️ Playbook **${label}** finished with errors.`
+      : `✅ Playbook **${label}** complete.`,
+  ];
+  if (typeof event.totalTasksCompleted === 'number') {
+    lines.push(`Tasks completed: **${event.totalTasksCompleted}**`);
+  }
+  if (typeof event.totalElapsedMs === 'number') {
+    const seconds = (event.totalElapsedMs / 1000).toFixed(1);
+    lines.push(`Elapsed: ${seconds}s`);
+  }
+  if (typeof event.totalCost === 'number' && event.totalCost > 0) {
+    lines.push(`Cost: $${event.totalCost.toFixed(4)}`);
+  }
+  if (event.summary) {
+    const summary = String(event.summary).slice(0, 1500);
+    lines.push('', summary);
+  }
+
+  await interaction.editReply(lines.join('\n'));
+}

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -3,8 +3,20 @@ import { config } from './config';
 import * as health from './commands/health';
 import * as agents from './commands/agents';
 import * as session from './commands/session';
+import * as playbook from './commands/playbook';
+import * as gist from './commands/gist';
+import * as notes from './commands/notes';
+import * as autoRun from './commands/auto-run';
 
-const commands = [health.data.toJSON(), agents.data.toJSON(), session.data.toJSON()];
+const commands = [
+  health.data.toJSON(),
+  agents.data.toJSON(),
+  session.data.toJSON(),
+  playbook.data.toJSON(),
+  gist.data.toJSON(),
+  notes.data.toJSON(),
+  autoRun.data.toJSON(),
+];
 
 const rest = new REST().setToken(config.token);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,38 @@
-import { Client, GatewayIntentBits, Interaction } from 'discord.js';
+import {
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  Client,
+  GatewayIntentBits,
+  Interaction,
+  SlashCommandBuilder,
+} from 'discord.js';
 import { config } from './config';
 import * as health from './commands/health';
 import * as agents from './commands/agents';
 import * as session from './commands/session';
+import * as playbook from './commands/playbook';
+import * as gist from './commands/gist';
+import * as notes from './commands/notes';
+import * as autoRun from './commands/auto-run';
 import './db'; // ensure DB is initialized on startup
+
+interface CommandModule {
+  data: { name: string } & Pick<SlashCommandBuilder, 'toJSON'>;
+  execute(interaction: ChatInputCommandInteraction): Promise<void>;
+  autocomplete?(interaction: AutocompleteInteraction): Promise<void>;
+}
 import { checkTranscriptionDependencies } from './services/transcription';
 import { handleMessageCreate } from './handlers/messageCreate';
 import { startServer } from './server';
 
-const commands = new Map([
+const commands = new Map<string, CommandModule>([
   [health.data.name, health],
   [agents.data.name, agents],
   [session.data.name, session],
+  [playbook.data.name, playbook],
+  [gist.data.name, gist],
+  [notes.data.name, notes],
+  [autoRun.data.name, autoRun],
 ]);
 
 const client = new Client({
@@ -39,9 +60,7 @@ client.on('interactionCreate', async (interaction: Interaction) => {
       await interaction.respond([]);
       return;
     }
-    const cmd = commands.get(interaction.commandName) as {
-      autocomplete?: (i: typeof interaction) => Promise<void>;
-    };
+    const cmd = commands.get(interaction.commandName);
     if (cmd?.autocomplete) {
       try {
         await cmd.autocomplete(interaction);

--- a/src/services/maestro.ts
+++ b/src/services/maestro.ts
@@ -55,6 +55,63 @@ export interface MaestroPlaybook {
   [key: string]: unknown;
 }
 
+export interface MaestroAgentDetail extends MaestroAgent {
+  projectRoot?: string;
+  groupName?: string;
+  autoRunFolderPath?: string;
+  stats?: {
+    historyEntries?: number;
+    successCount?: number;
+    failureCount?: number;
+    totalInputTokens?: number;
+    totalOutputTokens?: number;
+    totalCost?: number;
+    totalElapsedMs?: number;
+  };
+  recentHistory?: Array<{
+    id: string;
+    type: string;
+    timestamp: number;
+    summary: string;
+    success?: boolean;
+    elapsedTimeMs?: number;
+  }>;
+}
+
+export interface GistResult {
+  url: string;
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface DirectorNotesEntry {
+  id?: string;
+  type?: string;
+  timestamp?: number;
+  summary?: string;
+  agentName?: string;
+  success?: boolean;
+  [key: string]: unknown;
+}
+
+export interface DirectorSynopsis {
+  synopsis?: string;
+  text?: string;
+  markdown?: string;
+  daysCovered?: number;
+  entriesAnalyzed?: number;
+  [key: string]: unknown;
+}
+
+export interface AutoRunOptions {
+  agentId: string;
+  docs: string[];
+  prompt?: string;
+  loop?: boolean;
+  maxLoops?: number;
+  resetOnCompletion?: boolean;
+}
+
 export interface MaestroPlaybookDetail extends MaestroPlaybook {
   documents: Array<{
     path: string;
@@ -252,6 +309,60 @@ export const maestro = {
   async showPlaybook(playbookId: string): Promise<MaestroPlaybookDetail> {
     const raw = await run(['show', 'playbook', playbookId, '--json']);
     return JSON.parse(raw) as MaestroPlaybookDetail;
+  },
+
+  /** Show detailed agent info including stats and recent history */
+  async showAgent(agentId: string): Promise<MaestroAgentDetail> {
+    const raw = await run(['show', 'agent', agentId, '--json']);
+    return JSON.parse(raw) as MaestroAgentDetail;
+  },
+
+  /** Publish an agent's session transcript as a GitHub gist */
+  async createGist(
+    agentId: string,
+    opts: { description?: string; isPublic?: boolean } = {},
+  ): Promise<GistResult> {
+    const args = ['gist', 'create', agentId];
+    if (opts.description) args.push('-d', opts.description);
+    if (opts.isPublic) args.push('-p');
+    const raw = await run(args, { timeoutMs: 60_000 });
+    return JSON.parse(raw) as GistResult;
+  },
+
+  /** Generate AI synopsis of recent activity (requires running Maestro app) */
+  async directorSynopsis(opts: { days?: number } = {}): Promise<DirectorSynopsis> {
+    const args = ['director-notes', 'synopsis', '--json'];
+    if (opts.days != null) args.push('-d', String(opts.days));
+    // Synopsis generation involves AI inference — give it 2 minutes
+    const raw = await run(args, { timeoutMs: 120_000 });
+    return JSON.parse(raw) as DirectorSynopsis;
+  },
+
+  /** Show unified history across all agents */
+  async directorHistory(
+    opts: { days?: number; limit?: number; filter?: 'auto' | 'user' | 'cue' } = {},
+  ): Promise<DirectorNotesEntry[]> {
+    const args = ['director-notes', 'history', '--json'];
+    if (opts.days != null) args.push('-d', String(opts.days));
+    if (opts.limit != null) args.push('-l', String(opts.limit));
+    if (opts.filter) args.push('--filter', opts.filter);
+    const raw = await run(args);
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed as DirectorNotesEntry[];
+    if (Array.isArray(parsed?.entries)) return parsed.entries as DirectorNotesEntry[];
+    return [];
+  },
+
+  /** Configure and launch an Auto Run with the given documents */
+  async startAutoRun(opts: AutoRunOptions): Promise<string> {
+    if (!opts.docs.length) throw new Error('startAutoRun requires at least one document');
+    const args = ['auto-run', '--launch', '--agent', opts.agentId];
+    if (opts.prompt) args.push('--prompt', opts.prompt);
+    if (opts.maxLoops != null) args.push('--max-loops', String(opts.maxLoops));
+    else if (opts.loop) args.push('--loop');
+    if (opts.resetOnCompletion) args.push('--reset-on-completion');
+    args.push(...opts.docs);
+    return run(args, { timeoutMs: 60_000 });
   },
 
   /** Run a playbook and return the final completion event. Uses --wait so the CLI blocks until done. */

--- a/src/utils/embed.ts
+++ b/src/utils/embed.ts
@@ -1,4 +1,5 @@
 // Discord embed limits — see https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
+export const EMBED_TITLE_MAX = 256;
 export const EMBED_DESCRIPTION_MAX = 4096;
 export const EMBED_FIELD_VALUE_MAX = 1024;
 const ELLIPSIS = '\n…';
@@ -10,5 +11,6 @@ export function clampText(text: string, max: number): string {
   return text.slice(0, max - ELLIPSIS.length) + ELLIPSIS;
 }
 
+export const clampTitle = (text: string): string => clampText(text, EMBED_TITLE_MAX);
 export const clampDescription = (text: string): string => clampText(text, EMBED_DESCRIPTION_MAX);
 export const clampFieldValue = (text: string): string => clampText(text, EMBED_FIELD_VALUE_MAX);

--- a/src/utils/embed.ts
+++ b/src/utils/embed.ts
@@ -1,0 +1,14 @@
+// Discord embed limits — see https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
+export const EMBED_DESCRIPTION_MAX = 4096;
+export const EMBED_FIELD_VALUE_MAX = 1024;
+const ELLIPSIS = '\n…';
+
+/** Truncate `text` to `max` chars, appending an ellipsis marker if truncated. */
+export function clampText(text: string, max: number): string {
+  if (text.length <= max) return text;
+  if (max <= ELLIPSIS.length) return text.slice(0, max);
+  return text.slice(0, max - ELLIPSIS.length) + ELLIPSIS;
+}
+
+export const clampDescription = (text: string): string => clampText(text, EMBED_DESCRIPTION_MAX);
+export const clampFieldValue = (text: string): string => clampText(text, EMBED_FIELD_VALUE_MAX);


### PR DESCRIPTION
## Summary

Two related pieces of work that surface previously-unused `maestro-cli` capabilities to the bot and to agents:

1. **`maestro-discord` CLI** — restructured into verb-based commands (`send`, `notify`, `status`) so the agent→Discord surface can grow without flag-explosion.
2. **Five new slash commands** — `/playbook` (list/show/run), `/agents show`, `/gist`, `/notes` (synopsis/history), `/auto-run start`.

## What's in the box

### CLI (`bin/maestro-discord`)

- `send` — same behavior as the old top-level form, now under a verb
- `notify toast|flash` — formats a styled message with a color-coded emoji prefix and posts to the agent's channel
- `status` — pulls the agent's stats from `maestro-cli show agent --json` and posts a status card

All three ride the existing `POST /api/send` endpoint; no server changes.

### Slash commands

| Command | Notes |
|---|---|
| `/playbook list [agent]` | Embed of all playbooks; agent autocomplete |
| `/playbook show <id>` | Description, doc list with task progress |
| `/playbook run <id>` | **Public** reply; blocks until `complete` event; posts cost + elapsed |
| `/agents show <id>` | Stats, token totals, last 5 history entries |
| `/gist [description] [public]` | Publishes current channel's agent transcript as a gist |
| `/notes synopsis [days]` | AI-generated synopsis (2 min LLM timeout) |
| `/notes history [days/limit/filter]` | Unified history feed across agents |
| `/auto-run start <doc>` | Bare filenames resolve against agent's `autoRunFolderPath`; `.md` autocomplete |

### Service & wiring

- `src/services/maestro.ts` gains `showAgent`, `createGist`, `directorSynopsis`, `directorHistory`, `startAutoRun` plus their types.
- `src/index.ts` introduces a `CommandModule` type so the registry Map unifies across `SlashCommandBuilder`, `SlashCommandSubcommandsOnlyBuilder`, and `SlashCommandOptionsOnlyBuilder`.
- `src/deploy-commands.ts` registers the four new commands.
- `README.md` slash-command table updated.

## Verification

- `tsc --noEmit` clean
- `eslint src` clean (only one pre-existing warning in `transcription.ts`, untouched)
- `npm test` — 110/110 pass
- `npm run build` — all new commands emit to `dist/commands/`

## Test plan

- [ ] Run `npm run deploy-commands` after merge to register the new slash commands with Discord
- [ ] `/playbook list` shows playbooks; agent filter narrows the list
- [ ] `/playbook show <id>` renders an embed with description and doc list
- [ ] `/playbook run <id>` posts a public completion summary with elapsed/cost
- [ ] `/agents show <id>` renders stats and recent activity
- [ ] `/gist` in an agent channel returns a clickable gist URL; `public:true` makes it public
- [ ] `/notes synopsis` returns an AI summary (allow up to ~2 min)
- [ ] `/notes history` returns recent entries; filters narrow them
- [ ] `/auto-run start` autocomplete lists `.md` files from the agent's Auto Run folder; selecting one launches the run
- [ ] `maestro-discord send --agent <id> --message "hi"` still posts to Discord (renamed surface)
- [ ] `maestro-discord notify toast --agent <id> --title T --message M --color red` posts a 🔴 prefixed embed
- [ ] `maestro-discord status --agent <id>` posts a status card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * /agents show — view detailed agent info with stats and recent activity; improved channel creation handling with friendly errors
  * /playbook — list, show, and run playbooks (clamped/truncated embed content)
  * /auto-run start — launch Auto Run documents with path resolution and autocomplete
  * /gist — publish session transcripts as GitHub gists
  * /notes — synopsis and history commands
  * Maestro-Discord CLI verbs: send, notify, status (new verb-based CLI)

* **Documentation**
  * README and docs updated with expanded slash-commands and CLI usage examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->