### PR TITLE
chore(rename): follow-up repo transition to Maestro-Relay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # --- Core (provider-neutral) ---
 ENABLED_PROVIDERS=discord  # comma-separated list of bridge providers to enable (default: discord)
-API_PORT=3457              # optional: port for the internal HTTP API used by maestro-bridge CLI
+API_PORT=3457              # optional: port for the internal HTTP API used by maestro-relay CLI
 FFMPEG_PATH=ffmpeg                # optional: override ffmpeg executable path
 WHISPER_CLI_PATH=whisper-cli      # optional: override whisper-cli executable path
 # mkdir -p ./models && curl -L -o models/ggml-base.en.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Guide
 
-This repo is **Maestro Bridge** — a chat-platform-to-Maestro bridge built around a provider-agnostic kernel. Discord is the first provider; Slack/Teams plug in alongside it without touching the kernel. CLAUDE.md is a symlink to this file.
+This repo is **Maestro Relay** — a chat-platform-to-Maestro bridge built around a provider-agnostic kernel. Discord is the first provider; Slack/Teams plug in alongside it without touching the kernel. CLAUDE.md is a symlink to this file.
 
 ## Development workflow
 
@@ -40,11 +40,11 @@ This repo is **Maestro Bridge** — a chat-platform-to-Maestro bridge built arou
 
 ### CLI
 
-- `src/cli/maestro-bridge.ts` — verb dispatcher (`send`, `notify`, `status`)
+- `src/cli/maestro-relay.ts` — verb dispatcher (`send`, `notify`, `status`)
 - `src/cli/lib.ts` — shared HTTP client for `/api/send`
 - `src/cli/verbs/` — individual verb implementations
 
-The `maestro-discord` binary is registered as an alias of `maestro-bridge` for back-compat.
+The `maestro-discord` binary is registered as an alias of `maestro-relay` for back-compat.
 
 ### Entry point
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Maestro Bridge
+# Maestro Relay
 
 [![Made with Maestro](https://raw.githubusercontent.com/RunMaestro/Maestro/main/docs/assets/made-with-maestro.svg)](https://github.com/RunMaestro/Maestro)
 
-**Maestro Bridge** connects chat platforms to [Maestro](https://runmaestro.ai) AI agents through `maestro-cli`. Discord ships in the box; Slack, Teams, and others can be added by dropping in a provider adapter — the kernel is provider-agnostic.
+**Maestro Relay** connects chat platforms to [Maestro](https://runmaestro.ai) AI agents through `maestro-cli`. Discord ships in the box; Slack, Teams, and others can be added by dropping in a provider adapter — the kernel is provider-agnostic.
 
 > **Migrating from `discord-maestro`?** Same codebase, new name. The legacy `maestro-discord` binary is preserved as an alias and all `DISCORD_*` env vars work unchanged. See "Migration" below.
 
@@ -21,16 +21,16 @@
 - A Discord application + bot token (if running the Discord provider)
 - [Maestro CLI](https://docs.runmaestro.ai/cli) on your `PATH`
 
-### Install the `maestro-bridge` CLI
+### Install the `maestro-relay` CLI
 
-The `maestro-bridge` CLI lets your Maestro agents reach out to chat — for example, to ping you when a long-running task finishes. See [docs/api.md](docs/api.md) for usage.
+The `maestro-relay` CLI lets your Maestro agents reach out to chat — for example, to ping you when a long-running task finishes. See [docs/api.md](docs/api.md) for usage.
 
 After building (`npm run build`), create a shell wrapper.
 
 macOS / Linux:
 
 ```bash
-printf '#!/bin/bash\nnode "%s/dist/cli/maestro-bridge.js" "$@"\n' "$(pwd)" | sudo tee /usr/local/bin/maestro-bridge && sudo chmod +x /usr/local/bin/maestro-bridge
+printf '#!/bin/bash\nnode "%s/dist/cli/maestro-relay.js" "$@"\n' "$(pwd)" | sudo tee /usr/local/bin/maestro-relay && sudo chmod +x /usr/local/bin/maestro-relay
 ```
 
 Windows (PowerShell) — writes the wrapper to `%USERPROFILE%\bin` and adds it to your user `PATH`:
@@ -41,8 +41,8 @@ $binDir = "$env:USERPROFILE\bin"
 New-Item -ItemType Directory -Force -Path $binDir | Out-Null
 @"
 @echo off
-node "$repoPath\dist\cli\maestro-bridge.js" %*
-"@ | Out-File -FilePath "$binDir\maestro-bridge.cmd" -Encoding ASCII
+node "$repoPath\dist\cli\maestro-relay.js" %*
+"@ | Out-File -FilePath "$binDir\maestro-relay.cmd" -Encoding ASCII
 
 # Add $binDir to user PATH if it isn't already (restart your shell afterwards)
 $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
@@ -54,11 +54,11 @@ if (-not ($userPath -split ';' -contains $binDir)) {
 Or use `npm link`:
 
 ```bash
-maestro-discord-ctl start     # boot the bot
-maestro-discord-ctl logs      # tail logs
-maestro-discord-ctl status    # service status
-maestro-discord-ctl update    # upgrade to latest release (preserves config)
-maestro-discord-ctl uninstall # remove install + service files
+maestro-relay-ctl start     # boot the bot
+maestro-relay-ctl logs      # tail logs
+maestro-relay-ctl status    # service status
+maestro-relay-ctl update    # upgrade to latest release (preserves config)
+maestro-relay-ctl uninstall # remove install + service files
 ```
 
 The legacy `maestro-discord` binary is registered as an alias to the same JS, so existing scripts keep working.
@@ -67,20 +67,20 @@ The legacy `maestro-discord` binary is registered as an alias to the same JS, so
 
 | Path                          | Purpose                                  |
 | ----------------------------- | ---------------------------------------- |
-| `~/.local/share/maestro-discord/` | Installed bot (built JS + dependencies) |
-| `~/.config/maestro-discord/.env`  | Configuration (preserved across updates) |
-| `~/.local/bin/maestro-discord-ctl` | Service control wrapper             |
+| `~/.local/share/maestro-relay/` | Installed bot (built JS + dependencies) |
+| `~/.config/maestro-relay/.env`  | Configuration (preserved across updates) |
+| `~/.local/bin/maestro-relay-ctl` | Service control wrapper             |
 | systemd user / launchd agent  | Auto-start unit                          |
 
-Override any of these with `MAESTRO_DISCORD_HOME`, `XDG_CONFIG_HOME`, or `MAESTRO_DISCORD_BIN_DIR`. Pin a specific version with `MAESTRO_DISCORD_VERSION=v1.0.0`.
+Override any of these with `MAESTRO_RELAY_HOME`, `XDG_CONFIG_HOME`, or `MAESTRO_RELAY_BIN_DIR`. Pin a specific version with `MAESTRO_RELAY_VERSION=v1.0.0`.
 
 ## Install (development from source)
 
 1. Clone and install:
 
 ```bash
-git clone https://github.com/RunMaestro/Maestro-Discord.git
-cd Maestro-Discord
+git clone https://github.com/RunMaestro/Maestro-Relay.git
+cd Maestro-Relay
 npm install
 ```
 
@@ -122,7 +122,7 @@ npm run deploy-commands
 npm run dev
 ```
 
-### Install maestro-discord CLI (dev)
+### Install maestro-relay CLI (dev)
 
 The `maestro-discord` CLI lets your Maestro agents reach out to you on Discord — for example, to ping you when a long-running task finishes. See [docs/api.md](docs/api.md) for usage.
 
@@ -131,7 +131,7 @@ After building the project (`npm run build`), create a shell wrapper.
 macOS / Linux:
 
 ```bash
-printf '#!/bin/bash\nnode "%s/dist/cli/maestro-discord.js" "$@"\n' "$(pwd)" | sudo tee /usr/local/bin/maestro-discord && sudo chmod +x /usr/local/bin/maestro-discord
+printf '#!/bin/bash\nnode "%s/dist/cli/maestro-relay.js" "$@"\n' "$(pwd)" | sudo tee /usr/local/bin/maestro-discord && sudo chmod +x /usr/local/bin/maestro-discord
 ```
 
 Windows (PowerShell) — writes the wrapper to `%USERPROFILE%\bin` and adds it to your user `PATH`:
@@ -142,7 +142,7 @@ $binDir = "$env:USERPROFILE\bin"
 New-Item -ItemType Directory -Force -Path $binDir | Out-Null
 @"
 @echo off
-node "$repoPath\dist\cli\maestro-discord.js" %*
+node "$repoPath\dist\cli\maestro-relay.js" %*
 "@ | Out-File -FilePath "$binDir\maestro-discord.cmd" -Encoding ASCII
 
 # Add $binDir to user PATH if it isn't already (restart your shell afterwards)
@@ -180,17 +180,17 @@ brew install ffmpeg whisper-cli
 
    On Linux/Windows, install ffmpeg via your package manager and either build `whisper-cli` from the [whisper.cpp](https://github.com/ggerganov/whisper.cpp) repo (then symlink the binary into `~/.local/bin`) or use [Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux).
 
-2. **Production install (curl one-liner)** — the installer detects `ffmpeg` + `whisper-cli` on `PATH` and asks whether to enable voice transcription. If you say yes, it asks whether you already have a `ggml-*.bin` model file — paste the absolute path to reuse it, or let it download `ggml-base.en.bin` (~142 MB) into `~/.local/share/maestro-discord/models/`. Resolved **absolute** paths are written into `~/.config/maestro-discord/.env`, so the systemd/launchd service finds them regardless of `PATH`.
+2. **Production install (curl one-liner)** — the installer detects `ffmpeg` + `whisper-cli` on `PATH` and asks whether to enable voice transcription. If you say yes, it asks whether you already have a `ggml-*.bin` model file — paste the absolute path to reuse it, or let it download `ggml-base.en.bin` (~142 MB) into `~/.local/share/maestro-relay/models/`. Resolved **absolute** paths are written into `~/.config/maestro-relay/.env`, so the systemd/launchd service finds them regardless of `PATH`.
 
    Non-interactive escape hatches:
 
    ```bash
-   MAESTRO_DISCORD_VOICE=1 \
-   MAESTRO_DISCORD_MODEL=/abs/path/to/ggml-base.en.bin \
-     bash -c "$(curl -fsSL https://raw.githubusercontent.com/RunMaestro/Maestro-Discord/main/install.sh)"
+   MAESTRO_RELAY_VOICE=1 \
+   MAESTRO_RELAY_MODEL=/abs/path/to/ggml-base.en.bin \
+     bash -c "$(curl -fsSL https://raw.githubusercontent.com/RunMaestro/Maestro-Relay/main/install.sh)"
    ```
 
-   `MAESTRO_DISCORD_VOICE=0` opts out; omitting `MAESTRO_DISCORD_MODEL` triggers the download.
+   `MAESTRO_RELAY_VOICE=0` opts out; omitting `MAESTRO_RELAY_MODEL` triggers the download.
 
 3. **Source install** (npm-based) — there's no wizard; download a model and set the paths yourself:
 
@@ -252,13 +252,13 @@ Mention the bot or run `/session new` in an agent channel to create a thread, th
 
 ## Agent → chat messaging
 
-Agents can push messages to chat via the `maestro-bridge` CLI / HTTP API. See [docs/api.md](docs/api.md) for usage, endpoints, and error codes.
+Agents can push messages to chat via the `maestro-relay` CLI / HTTP API. See [docs/api.md](docs/api.md) for usage, endpoints, and error codes.
 
 ## Migration from `discord-maestro`
 
 This project was renamed from `discord-maestro` / `Maestro-Discord`. To smooth upgrades:
 
-- The `maestro-discord` binary is preserved as an alias of `maestro-bridge`. Existing scripts that call `maestro-discord send …` keep working unchanged.
+- The `maestro-discord` binary is preserved as an alias of `maestro-relay`. Existing scripts that call `maestro-discord send …` keep working unchanged.
 - All `DISCORD_*` env vars are unchanged. New optional `ENABLED_PROVIDERS` defaults to `discord`.
 - The SQLite database upgrades automatically on first start: `agent_channels` gains a `provider` column (existing rows default to `discord`); `agent_threads` is renamed to `discord_agent_threads` with rows preserved. No manual migration needed.
 - The HTTP `/api/send` endpoint accepts an optional `provider` field that defaults to `discord`; existing callers are unaffected.

--- a/bin/maestro-relay-ctl.sh
+++ b/bin/maestro-relay-ctl.sh
@@ -1,38 +1,42 @@
 #!/usr/bin/env bash
-# Service wrapper for the Maestro Bridge.
+# Service wrapper for the Maestro Relay.
 # Subcommands: start | stop | restart | status | logs | deploy | update | uninstall | version
 #
-# Backwards-compat: legacy MAESTRO_DISCORD_* env vars are accepted as fallback.
-# A legacy install at ~/.local/share/maestro-discord is auto-detected when
+# Backwards-compat: legacy MAESTRO_BRIDGE_* / MAESTRO_DISCORD_* env vars are accepted as fallback.
+# A legacy install at ~/.local/share/maestro-bridge or ~/.local/share/maestro-discord is auto-detected when
 # the new install dir doesn't exist.
 
 set -euo pipefail
 
-# Resolve install paths with MAESTRO_DISCORD_* fallback for back-compat.
-INSTALL_DIR="${MAESTRO_BRIDGE_HOME:-${MAESTRO_DISCORD_HOME:-}}"
+# Resolve install paths with MAESTRO_BRIDGE_* / MAESTRO_DISCORD_* fallback for back-compat.
+INSTALL_DIR="${MAESTRO_RELAY_HOME:-${MAESTRO_BRIDGE_HOME:-${MAESTRO_DISCORD_HOME:-}}}"
 if [ -z "$INSTALL_DIR" ]; then
-  if [ -d "$HOME/.local/share/maestro-bridge" ]; then
+  if [ -d "$HOME/.local/share/maestro-relay" ]; then
+    INSTALL_DIR="$HOME/.local/share/maestro-relay"
+  elif [ -d "$HOME/.local/share/maestro-bridge" ]; then
     INSTALL_DIR="$HOME/.local/share/maestro-bridge"
   elif [ -d "$HOME/.local/share/maestro-discord" ]; then
     INSTALL_DIR="$HOME/.local/share/maestro-discord"
   else
-    INSTALL_DIR="$HOME/.local/share/maestro-bridge"
+    INSTALL_DIR="$HOME/.local/share/maestro-relay"
   fi
 fi
 
 XDG_CONFIG_PARENT="${XDG_CONFIG_HOME:-$HOME/.config}"
-if [ -d "$XDG_CONFIG_PARENT/maestro-bridge" ]; then
+if [ -d "$XDG_CONFIG_PARENT/maestro-relay" ]; then
+  CONFIG_DIR="$XDG_CONFIG_PARENT/maestro-relay"
+elif [ -d "$XDG_CONFIG_PARENT/maestro-bridge" ]; then
   CONFIG_DIR="$XDG_CONFIG_PARENT/maestro-bridge"
 elif [ -d "$XDG_CONFIG_PARENT/maestro-discord" ]; then
   CONFIG_DIR="$XDG_CONFIG_PARENT/maestro-discord"
 else
-  CONFIG_DIR="$XDG_CONFIG_PARENT/maestro-bridge"
+  CONFIG_DIR="$XDG_CONFIG_PARENT/maestro-relay"
 fi
 
-BIN_DIR="${MAESTRO_BRIDGE_BIN_DIR:-${MAESTRO_DISCORD_BIN_DIR:-$HOME/.local/bin}}"
-REPO="${MAESTRO_BRIDGE_REPO:-${MAESTRO_DISCORD_REPO:-RunMaestro/Maestro-Bridge}}"
-SERVICE_NAME="maestro-bridge"
-LAUNCHD_LABEL="sh.maestro.bridge"
+BIN_DIR="${MAESTRO_RELAY_BIN_DIR:-${MAESTRO_BRIDGE_BIN_DIR:-${MAESTRO_DISCORD_BIN_DIR:-$HOME/.local/bin}}}"
+REPO="${MAESTRO_RELAY_REPO:-${MAESTRO_BRIDGE_REPO:-${MAESTRO_DISCORD_REPO:-RunMaestro/Maestro-Relay}}}"
+SERVICE_NAME="maestro-relay"
+LAUNCHD_LABEL="sh.maestro.relay"
 LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
 # Legacy names — used by uninstall to clean up after a v0.0.x install.
 LEGACY_SERVICE_NAME="maestro-discord"
@@ -52,26 +56,27 @@ detect_os() {
 
 usage() {
   cat <<'EOF'
-maestro-bridge-ctl — control the Maestro Bridge service.
-(Alias: maestro-discord-ctl, preserved for back-compat.)
+maestro-relay-ctl — control the Maestro Relay service.
+(Aliases: maestro-bridge-ctl and maestro-discord-ctl, preserved for back-compat.)
 
 Usage:
-  maestro-bridge-ctl <command>
+  maestro-relay-ctl <command>
 
 Commands:
-  start       Start the bridge service
-  stop        Stop the bridge service
-  restart     Restart the bridge service
+  start       Start the relay service
+  stop        Stop the relay service
+  restart     Restart the relay service
   status      Show service status
   logs        Tail service logs (Ctrl+C to stop)
   deploy      Deploy slash commands to Discord
   update      Reinstall the latest release (preserves config)
-  uninstall   Remove the bridge, service files, and CLI symlink
+  uninstall   Remove the relay, service files, and CLI symlinks
   version     Print installed version
 
 Environment:
-  MAESTRO_BRIDGE_HOME    Override install dir  (default: ~/.local/share/maestro-bridge)
+  MAESTRO_RELAY_HOME    Override install dir  (default: ~/.local/share/maestro-relay)
   XDG_CONFIG_HOME        Config dir parent     (default: ~/.config)
+  MAESTRO_BRIDGE_HOME    Accepted as fallback for back-compat
   MAESTRO_DISCORD_HOME   Accepted as fallback for back-compat with v0.0.x
 EOF
 }
@@ -127,7 +132,7 @@ cmd_logs() {
   case "$(detect_os)" in
     linux) journalctl --user -u "$SERVICE_NAME" -f --no-pager ;;
     macos)
-      local log_file="$INSTALL_DIR/logs/maestro-bridge.log"
+      local log_file="$INSTALL_DIR/logs/maestro-relay.log"
       mkdir -p "$INSTALL_DIR/logs"
       [ -f "$log_file" ] || touch "$log_file"
       tail -f "$log_file"
@@ -150,9 +155,9 @@ cmd_update() {
   config_parent="$(dirname "$CONFIG_DIR")"
   curl -fsSL "https://raw.githubusercontent.com/${REPO}/${tag}/install.sh" \
     | env \
-        MAESTRO_BRIDGE_HOME="$INSTALL_DIR" \
-        MAESTRO_BRIDGE_BIN_DIR="$BIN_DIR" \
-        MAESTRO_BRIDGE_REPO="$REPO" \
+        MAESTRO_RELAY_HOME="$INSTALL_DIR" \
+        MAESTRO_RELAY_BIN_DIR="$BIN_DIR" \
+        MAESTRO_RELAY_REPO="$REPO" \
         XDG_CONFIG_HOME="$config_parent" \
         bash
 }
@@ -169,6 +174,8 @@ cmd_uninstall() {
       systemctl --user disable --now "$SERVICE_NAME" 2>/dev/null || true
       rm -f "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/${SERVICE_NAME}.service"
       # Clean up legacy unit if present.
+      systemctl --user disable --now maestro-bridge 2>/dev/null || true
+      rm -f "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/maestro-bridge.service"
       systemctl --user disable --now "$LEGACY_SERVICE_NAME" 2>/dev/null || true
       rm -f "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/${LEGACY_SERVICE_NAME}.service"
       systemctl --user daemon-reload || true
@@ -177,6 +184,10 @@ cmd_uninstall() {
       ;;
     macos)
       rm -f "$LAUNCHD_PLIST"
+      [ -f "$HOME/Library/LaunchAgents/sh.maestro.bridge.plist" ] && {
+        launchctl unload -w "$HOME/Library/LaunchAgents/sh.maestro.bridge.plist" 2>/dev/null || true
+        rm -f "$HOME/Library/LaunchAgents/sh.maestro.bridge.plist"
+      }
       [ -f "$LEGACY_LAUNCHD_PLIST" ] && {
         launchctl unload -w "$LEGACY_LAUNCHD_PLIST" 2>/dev/null || true
         rm -f "$LEGACY_LAUNCHD_PLIST"
@@ -184,6 +195,7 @@ cmd_uninstall() {
       ;;
   esac
   rm -rf "$INSTALL_DIR"
+  rm -f "$BIN_DIR/maestro-relay-ctl"
   rm -f "$BIN_DIR/maestro-bridge-ctl"
   rm -f "$BIN_DIR/maestro-discord-ctl"
   info "Uninstalled. Config preserved at $CONFIG_DIR (delete manually if desired)."

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,8 +1,8 @@
-# Maestro Bridge HTTP API
+# Maestro Relay HTTP API
 
-Maestro agents can push messages into chat using the `maestro-bridge` CLI (or any HTTP client). The bridge exposes a local HTTP API on `127.0.0.1:API_PORT` (default 3457).
+Maestro agents can push messages into chat using the `maestro-relay` CLI (or any HTTP client). The bridge exposes a local HTTP API on `127.0.0.1:API_PORT` (default 3457).
 
-The legacy binary name `maestro-discord` is preserved as an alias of `maestro-bridge` and is fully equivalent.
+The legacy binary name `maestro-discord` is preserved as an alias of `maestro-relay` and is fully equivalent.
 
 ## Setup
 
@@ -10,26 +10,26 @@ The API server starts automatically with the bridge. Port is configurable via `A
 
 ## CLI usage
 
-`maestro-discord` is verb-based. Run `maestro-discord --help` for the full
-list, or `maestro-discord <verb> --help` for verb-specific options.
+`maestro-relay` is verb-based. Run `maestro-relay --help` for the full
+list, or `maestro-relay <verb> --help` for verb-specific options.
 
 ```bash
 # Send a message to an agent's bridge channel (default provider: discord)
-maestro-bridge send --agent <agent-id> --message "Hello from Maestro"
+maestro-relay send --agent <agent-id> --message "Hello from Maestro"
 
 # Send with @mention (uses the provider's configured mention target,
 # e.g. DISCORD_MENTION_USER_ID for the Discord provider)
-maestro-bridge send --agent <agent-id> --message "Build complete!" --mention
+maestro-relay send --agent <agent-id> --message "Build complete!" --mention
 
 # Use a custom port
-maestro-bridge send --agent <agent-id> --message "Hello" --port 4000
+maestro-relay send --agent <agent-id> --message "Hello" --port 4000
 
 # Post a styled toast or flash notification
-maestro-bridge notify toast --agent <id> --title "Deploy" --message "Done" --color green
-maestro-bridge notify flash --agent <id> --message "Tests passing" --color green
+maestro-relay notify toast --agent <id> --title "Deploy" --message "Done" --color green
+maestro-relay notify flash --agent <id> --message "Tests passing" --color green
 
 # Post the agent's current status (pulls from `maestro-cli show agent --json`)
-maestro-bridge status --agent <id>
+maestro-relay status --agent <id>
 ```
 
 If the agent doesn't have a connected channel yet, one is auto-created.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Maestro Bridge is built around a **provider-agnostic kernel** plus pluggable **provider adapters**. The kernel handles queueing, agent dispatch, persistence, transcription, and the HTTP API; adapters translate platform events into a small set of kernel types and back out into platform actions.
+Maestro Relay is built around a **provider-agnostic kernel** plus pluggable **provider adapters**. The kernel handles queueing, agent dispatch, persistence, transcription, and the HTTP API; adapters translate platform events into a small set of kernel types and back out into platform actions.
 
 ## Kernel ↔ Provider contract
 
@@ -73,7 +73,7 @@ The schema upgrades on first start: legacy `agent_channels` (single-PK `channel_
 | `src/providers/discord/voice.ts`              | Discord voice-message detection                        |
 | `src/providers/discord/commands/`             | Slash command handlers                                 |
 | `src/providers/discord/deploy.ts`             | Registers slash commands with Discord API              |
-| `src/cli/maestro-bridge.ts`                   | CLI tool for agent → chat messaging                    |
+| `src/cli/maestro-relay.ts`                   | CLI tool for agent → chat messaging                    |
 | `src/index.ts`                                | Kernel orchestrator (entry point)                      |
 
 ## Adding a new provider

--- a/install.sh
+++ b/install.sh
@@ -1,25 +1,26 @@
 #!/usr/bin/env bash
-# Maestro Bridge installer.
+# Maestro Relay installer.
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/RunMaestro/Maestro-Bridge/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/RunMaestro/Maestro-Relay/main/install.sh | bash
 # Re-run to upgrade to the latest release. Existing config is preserved.
 #
-# Legacy MAESTRO_DISCORD_* env vars are accepted as fallback so v0.0.x
+# Legacy MAESTRO_BRIDGE_* / MAESTRO_DISCORD_* env vars are accepted as fallback so v0.0.x
 # installs upgrading via `maestro-discord-ctl update` keep working.
 
 set -Eeuo pipefail
 
-# Resolve config with MAESTRO_DISCORD_* fallback for back-compat with v0.0.x.
-REPO="${MAESTRO_BRIDGE_REPO:-${MAESTRO_DISCORD_REPO:-RunMaestro/Maestro-Bridge}}"
-INSTALL_DIR="${MAESTRO_BRIDGE_HOME:-${MAESTRO_DISCORD_HOME:-$HOME/.local/share/maestro-bridge}}"
-CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/maestro-bridge"
-# If a legacy ~/.config/maestro-discord exists and the new dir doesn't, prefer
-# the legacy location so existing users don't lose their .env.
-if [ ! -d "$CONFIG_DIR" ] && [ -d "${XDG_CONFIG_HOME:-$HOME/.config}/maestro-discord" ]; then
+# Resolve config with MAESTRO_BRIDGE_* / MAESTRO_DISCORD_* fallback for back-compat.
+REPO="${MAESTRO_RELAY_REPO:-${MAESTRO_BRIDGE_REPO:-${MAESTRO_DISCORD_REPO:-RunMaestro/Maestro-Relay}}}"
+INSTALL_DIR="${MAESTRO_RELAY_HOME:-${MAESTRO_BRIDGE_HOME:-${MAESTRO_DISCORD_HOME:-$HOME/.local/share/maestro-relay}}}"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/maestro-relay"
+# If a legacy config dir exists and the new dir doesn't, prefer legacy location.
+if [ ! -d "$CONFIG_DIR" ] && [ -d "${XDG_CONFIG_HOME:-$HOME/.config}/maestro-bridge" ]; then
+  CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/maestro-bridge"
+elif [ ! -d "$CONFIG_DIR" ] && [ -d "${XDG_CONFIG_HOME:-$HOME/.config}/maestro-discord" ]; then
   CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/maestro-discord"
 fi
-BIN_DIR="${MAESTRO_BRIDGE_BIN_DIR:-${MAESTRO_DISCORD_BIN_DIR:-$HOME/.local/bin}}"
-VERSION="${MAESTRO_BRIDGE_VERSION:-${MAESTRO_DISCORD_VERSION:-latest}}"
+BIN_DIR="${MAESTRO_RELAY_BIN_DIR:-${MAESTRO_BRIDGE_BIN_DIR:-${MAESTRO_DISCORD_BIN_DIR:-$HOME/.local/bin}}}"
+VERSION="${MAESTRO_RELAY_VERSION:-${MAESTRO_BRIDGE_VERSION:-${MAESTRO_DISCORD_VERSION:-latest}}}"
 NODE_MIN_MAJOR=22
 RELEASE_BACKUP=""
 
@@ -104,7 +105,7 @@ sha256_of() {
 
 download_release() {
   local tag="$1" dest="$2"
-  local url="https://github.com/${REPO}/releases/download/${tag}/maestro-bridge-${tag}.tar.gz"
+  local url="https://github.com/${REPO}/releases/download/${tag}/maestro-relay-${tag}.tar.gz"
   local sha_url="${url}.sha256"
   info "Downloading ${tag} from ${url}"
   curl -fsSL "$url" -o "$dest" || die "Download failed: $url"
@@ -271,14 +272,14 @@ deploy_commands() {
   local env_file="$CONFIG_DIR/.env"
   if ! config_complete "$env_file"; then
     warn "Skipping slash command deployment — config at $env_file is incomplete or contains template values."
-    warn "Edit it and run 'maestro-bridge-ctl deploy' when ready."
+    warn "Edit it and run 'maestro-relay-ctl deploy' when ready."
     return
   fi
   info "Deploying slash commands to Discord"
   if (cd "$INSTALL_DIR" && node dist/providers/discord/deploy.js); then
     ok "Slash commands deployed"
   else
-    warn "Slash command deployment failed. Edit $env_file and re-run 'maestro-bridge-ctl deploy'."
+    warn "Slash command deployment failed. Edit $env_file and re-run 'maestro-relay-ctl deploy'."
   fi
 }
 
@@ -303,16 +304,16 @@ prompt_yes_no() {
 }
 
 setup_voice_choose_model() {
-  local model_env="${MAESTRO_BRIDGE_MODEL:-${MAESTRO_DISCORD_MODEL:-}}"
+  local model_env="${MAESTRO_RELAY_MODEL:-${MAESTRO_BRIDGE_MODEL:-${MAESTRO_DISCORD_MODEL:-}}}"
   if [ -n "$model_env" ]; then
     local m
     m="$(expand_tilde "$model_env")"
     if [ -f "$m" ]; then
       VOICE_MODEL="$m"
-      ok "Using existing model from MAESTRO_BRIDGE_MODEL: $m"
+      ok "Using existing model from MAESTRO_RELAY_* env var: $m"
       return 0
     else
-      warn "MAESTRO_BRIDGE_MODEL=$m not found — falling back to download"
+      warn "Configured model path ($m) not found — falling back to download"
     fi
   fi
 
@@ -374,7 +375,7 @@ setup_voice() {
     info "Voice transcription deps not on PATH — installing without voice"
     [ -z "$ffmpeg_path" ]  && warn "  ffmpeg not found"
     [ -z "$whisper_path" ] && warn "  whisper-cli not found"
-    warn "Install both, then run 'maestro-bridge-ctl update' to enable transcription."
+    warn "Install both, then run 'maestro-relay-ctl update' to enable transcription."
     return 0
   fi
 
@@ -382,7 +383,7 @@ setup_voice() {
   ok "Found whisper-cli: $whisper_path"
 
   local enable=0
-  local voice_env="${MAESTRO_BRIDGE_VOICE:-${MAESTRO_DISCORD_VOICE:-}}"
+  local voice_env="${MAESTRO_RELAY_VOICE:-${MAESTRO_BRIDGE_VOICE:-${MAESTRO_DISCORD_VOICE:-}}}"
   if [ "$voice_env" = "1" ]; then
     enable=1
   elif [ "$voice_env" = "0" ]; then
@@ -393,7 +394,7 @@ setup_voice() {
       enable=1
     fi
   else
-    info "Non-interactive shell — skipping voice setup (set MAESTRO_BRIDGE_VOICE=1 to opt in)"
+    info "Non-interactive shell — skipping voice setup (set MAESTRO_RELAY_VOICE=1 to opt in)"
   fi
 
   if [ "$enable" -ne 1 ]; then
@@ -409,14 +410,15 @@ setup_voice() {
 
 install_ctl() {
   mkdir -p "$BIN_DIR"
-  local ctl="$INSTALL_DIR/bin/maestro-bridge-ctl.sh"
+  local ctl="$INSTALL_DIR/bin/maestro-relay-ctl.sh"
   [ -f "$ctl" ] || die "Control script missing at $ctl"
   chmod +x "$ctl"
+  ln -sf "$ctl" "$BIN_DIR/maestro-relay-ctl"
   ln -sf "$ctl" "$BIN_DIR/maestro-bridge-ctl"
   # Backwards-compat alias for users with `maestro-discord-ctl` in muscle memory
   # or in scripts. Both point at the same wrapper.
   ln -sf "$ctl" "$BIN_DIR/maestro-discord-ctl"
-  ok "Installed maestro-bridge-ctl → $BIN_DIR/maestro-bridge-ctl (alias: maestro-discord-ctl)"
+  ok "Installed maestro-relay-ctl → $BIN_DIR/maestro-relay-ctl (aliases: maestro-bridge-ctl, maestro-discord-ctl)"
   case ":$PATH:" in
     *":$BIN_DIR:"*) : ;;
     *) warn "$BIN_DIR is not on your PATH. Add it to your shell profile." ;;
@@ -427,13 +429,13 @@ install_service_linux() {
   command -v systemctl >/dev/null 2>&1 || { warn "systemctl not found — skipping service install."; return; }
   local unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
   mkdir -p "$unit_dir"
-  local template="$INSTALL_DIR/templates/maestro-bridge.service"
+  local template="$INSTALL_DIR/templates/maestro-relay.service"
   [ -f "$template" ] || { warn "Service template missing at $template"; return; }
   sed \
     -e "s|@INSTALL_DIR@|$INSTALL_DIR|g" \
     -e "s|@CONFIG_DIR@|$CONFIG_DIR|g" \
     -e "s|@NODE_BIN@|$(command -v node)|g" \
-    "$template" > "$unit_dir/maestro-bridge.service"
+    "$template" > "$unit_dir/maestro-relay.service"
   # Disable+remove a legacy maestro-discord unit if present so we don't leave
   # two competing user services running on upgrade.
   if [ -f "$unit_dir/maestro-discord.service" ]; then
@@ -441,9 +443,14 @@ install_service_linux() {
     rm -f "$unit_dir/maestro-discord.service"
     info "Removed legacy systemd unit maestro-discord.service"
   fi
+  if [ -f "$unit_dir/maestro-bridge.service" ]; then
+    systemctl --user disable --now maestro-bridge 2>/dev/null || true
+    rm -f "$unit_dir/maestro-bridge.service"
+    info "Removed legacy systemd unit maestro-bridge.service"
+  fi
   systemctl --user daemon-reload || true
-  ok "Installed systemd unit → $unit_dir/maestro-bridge.service"
-  echo "    Enable on login:  systemctl --user enable --now maestro-bridge"
+  ok "Installed systemd unit → $unit_dir/maestro-relay.service"
+  echo "    Enable on login:  systemctl --user enable --now maestro-relay"
   echo "    (and optionally:  loginctl enable-linger \$USER)"
 }
 
@@ -451,21 +458,26 @@ install_service_macos() {
   local plist_dir="$HOME/Library/LaunchAgents"
   mkdir -p "$plist_dir"
   mkdir -p "$INSTALL_DIR/logs"
-  local template="$INSTALL_DIR/templates/sh.maestro.bridge.plist"
+  local template="$INSTALL_DIR/templates/sh.maestro.relay.plist"
   [ -f "$template" ] || { warn "Plist template missing at $template"; return; }
   sed \
     -e "s|@INSTALL_DIR@|$INSTALL_DIR|g" \
     -e "s|@CONFIG_DIR@|$CONFIG_DIR|g" \
     -e "s|@NODE_BIN@|$(command -v node)|g" \
-    "$template" > "$plist_dir/sh.maestro.bridge.plist"
+    "$template" > "$plist_dir/sh.maestro.relay.plist"
   # Unload+remove a legacy launchd plist if present.
   if [ -f "$plist_dir/sh.maestro.discord.plist" ]; then
     launchctl unload -w "$plist_dir/sh.maestro.discord.plist" 2>/dev/null || true
     rm -f "$plist_dir/sh.maestro.discord.plist"
     info "Removed legacy launchd plist sh.maestro.discord.plist"
   fi
-  ok "Installed launchd plist → $plist_dir/sh.maestro.bridge.plist"
-  echo "    Load at login:  launchctl load -w $plist_dir/sh.maestro.bridge.plist"
+  if [ -f "$plist_dir/sh.maestro.bridge.plist" ]; then
+    launchctl unload -w "$plist_dir/sh.maestro.bridge.plist" 2>/dev/null || true
+    rm -f "$plist_dir/sh.maestro.bridge.plist"
+    info "Removed legacy launchd plist sh.maestro.bridge.plist"
+  fi
+  ok "Installed launchd plist → $plist_dir/sh.maestro.relay.plist"
+  echo "    Load at login:  launchctl load -w $plist_dir/sh.maestro.relay.plist"
 }
 
 install_service() {
@@ -476,7 +488,7 @@ install_service() {
 }
 
 main() {
-  c_bold 'Maestro Bridge installer'
+  c_bold 'Maestro Relay installer'
   echo
   echo
 
@@ -506,8 +518,8 @@ main() {
   echo
   ok "$(c_bold 'Install complete') — version $(c_green "$tag")"
   echo
-  echo "  Start:  $(c_bold 'maestro-bridge-ctl start')"
-  echo "  Logs:   $(c_bold 'maestro-bridge-ctl logs')"
+  echo "  Start:  $(c_bold 'maestro-relay-ctl start')"
+  echo "  Logs:   $(c_bold 'maestro-relay-ctl logs')"
   echo "  Config: $CONFIG_DIR/.env"
   echo
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "discord-maestro",
-  "version": "0.0.4",
+  "name": "maestro-relay",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "discord-maestro",
-      "version": "0.0.4",
+      "name": "maestro-relay",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
@@ -14,7 +14,9 @@
         "dotenv": "^16.0.0"
       },
       "bin": {
-        "maestro-discord": "dist/cli/maestro-discord.js"
+        "maestro-bridge": "dist/cli/maestro-relay.js",
+        "maestro-discord": "dist/cli/maestro-relay.js",
+        "maestro-relay": "dist/cli/maestro-relay.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,22 @@
 {
-  "name": "maestro-bridge",
+  "name": "maestro-relay",
   "version": "0.1.0",
-  "description": "Maestro Bridge — connect chat platforms (Discord today, Slack/Teams next) to Maestro AI agents via maestro-cli.",
+  "description": "Maestro Relay — connect chat platforms (Discord today, Slack/Teams next) to Maestro AI agents via maestro-cli.",
   "main": "dist/index.js",
   "bin": {
-    "maestro-bridge": "dist/cli/maestro-bridge.js",
-    "maestro-discord": "dist/cli/maestro-bridge.js"
+    "maestro-relay": "dist/cli/maestro-relay.js",
+    "maestro-bridge": "dist/cli/maestro-relay.js",
+    "maestro-discord": "dist/cli/maestro-relay.js"
   },
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "tsc",
+    "build": "rm -rf dist && tsc",
     "start": "node dist/index.js",
     "deploy-commands": "tsx src/providers/discord/deploy.ts",
     "test": "npm run build && node --test dist/__tests__/**/*.test.js",
-    "maestro-bridge": "tsx src/cli/maestro-bridge.ts",
-    "maestro-discord": "tsx src/cli/maestro-bridge.ts"
+    "maestro-relay": "tsx src/cli/maestro-relay.ts",
+    "maestro-bridge": "tsx src/cli/maestro-relay.ts",
+    "maestro-discord": "tsx src/cli/maestro-relay.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/cli/maestro-relay.ts
+++ b/src/cli/maestro-relay.ts
@@ -3,16 +3,16 @@ import { runNotify, notifyUsage } from './verbs/notify';
 import { runSend, sendUsage } from './verbs/send';
 import { runStatus, statusUsage } from './verbs/status';
 
-const ROOT_USAGE = `Usage: maestro-bridge <verb> [options]
+const ROOT_USAGE = `Usage: maestro-relay <verb> [options]
 
 Verbs:
   send      Send a message to an agent's bridge channel
   notify    Post a styled toast/flash notification to an agent's channel
   status    Post the agent's current status (cwd, usage, tokens) to its channel
 
-Run 'maestro-bridge <verb> --help' for verb-specific options.
+Run 'maestro-relay <verb> --help' for verb-specific options.
 
-Note: 'maestro-discord' is preserved as an alias for backwards compatibility.`;
+Aliases: 'maestro-bridge' and 'maestro-discord' are preserved for backwards compatibility.`;
 
 function printRootHelp(): void {
   console.log(ROOT_USAGE);

--- a/src/cli/verbs/notify.ts
+++ b/src/cli/verbs/notify.ts
@@ -1,7 +1,7 @@
 import { parseArgs } from 'node:util';
 import { DEFAULT_PORT, fail, ok, parsePort, postToSendApi } from '../lib';
 
-export const notifyUsage = `Usage: maestro-bridge notify <toast|flash> [options]
+export const notifyUsage = `Usage: maestro-relay notify <toast|flash> [options]
 
 Post a styled notification message to an agent's bridge channel. Color maps
 to a leading emoji so the alert stands out from regular messages.

--- a/src/cli/verbs/send.ts
+++ b/src/cli/verbs/send.ts
@@ -1,7 +1,7 @@
 import { parseArgs } from 'node:util';
 import { DEFAULT_PORT, fail, ok, parsePort, postToSendApi } from '../lib';
 
-export const sendUsage = `Usage: maestro-bridge send --agent <id> --message <text> [--mention] [--port <number>]
+export const sendUsage = `Usage: maestro-relay send --agent <id> --message <text> [--mention] [--port <number>]
 
 Send a message to an agent's bridge channel (auto-creates channel if needed).
 

--- a/src/cli/verbs/status.ts
+++ b/src/cli/verbs/status.ts
@@ -1,7 +1,7 @@
 import { parseArgs } from 'node:util';
 import { DEFAULT_PORT, fail, ok, parsePort, postToSendApi, runMaestroCli } from '../lib';
 
-export const statusUsage = `Usage: maestro-bridge status --agent <id> [--port <number>]
+export const statusUsage = `Usage: maestro-relay status --agent <id> [--port <number>]
 
 Fetch agent details from maestro-cli and post a formatted status summary to
 the agent's bridge channel.

--- a/src/core/transcription.ts
+++ b/src/core/transcription.ts
@@ -122,7 +122,7 @@ export async function transcribeVoiceAttachment(attachment: IncomingAttachment):
     );
   }
 
-  const tempDir = path.join(os.tmpdir(), `maestro-bridge-voice-${randomUUID()}`);
+  const tempDir = path.join(os.tmpdir(), `maestro-relay-voice-${randomUUID()}`);
   const inputPath = path.join(tempDir, 'input.ogg');
   const wavPath = path.join(tempDir, 'input.wav');
   const outputBase = path.join(tempDir, 'transcript');

--- a/templates/maestro-relay.service
+++ b/templates/maestro-relay.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Maestro Bridge
+Description=Maestro Relay
 After=network-online.target
 Wants=network-online.target
 StartLimitIntervalSec=300

--- a/templates/sh.maestro.relay.plist
+++ b/templates/sh.maestro.relay.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>sh.maestro.bridge</string>
+  <string>sh.maestro.relay</string>
   <key>WorkingDirectory</key>
   <string>@INSTALL_DIR@</string>
   <key>ProgramArguments</key>
@@ -20,8 +20,8 @@
     <false/>
   </dict>
   <key>StandardOutPath</key>
-  <string>@INSTALL_DIR@/logs/maestro-bridge.log</string>
+  <string>@INSTALL_DIR@/logs/maestro-relay.log</string>
   <key>StandardErrorPath</key>
-  <string>@INSTALL_DIR@/logs/maestro-bridge.log</string>
+  <string>@INSTALL_DIR@/logs/maestro-relay.log</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- switch primary naming from `maestro-bridge` to `maestro-relay` across package metadata, CLI entrypoints, installer/control scripts, service templates, and docs
- update installer/update defaults to `RunMaestro/Maestro-Relay`
- preserve compatibility aliases for legacy command names (`maestro-bridge`, `maestro-discord`, and corresponding `*-ctl` wrappers)
- add env fallback chain for upgrades: `MAESTRO_RELAY_* -> MAESTRO_BRIDGE_* -> MAESTRO_DISCORD_*`
- clean `dist` before compile to prevent stale artifact regressions (`build: rm -rf dist && tsc`)

## Validation
- `npm run build` passes
- `npm test` fails in this environment due existing `better-sqlite3` Node ABI mismatch (`NODE_MODULE_VERSION 141` vs `127`)