### PR TITLE
fix(installer): drop RETURN-trap leak and guard ctl deploy on template config

### DIFF
--- a/bin/maestro-relay-ctl.sh
+++ b/bin/maestro-relay-ctl.sh
@@ -142,10 +142,26 @@ cmd_logs() {
   esac
 }
 
+config_complete() {
+  local file="$1" key value
+  [ -f "$file" ] || return 1
+  for key in DISCORD_BOT_TOKEN DISCORD_CLIENT_ID DISCORD_GUILD_ID; do
+    value="$(sed -nE "s/^${key}=([^#[:space:]]+).*/\1/p" "$file" | head -n1)"
+    [ -n "$value" ] || return 1
+    case "$value" in
+      your_*) return 1 ;;
+    esac
+  done
+  return 0
+}
+
 cmd_deploy() {
   require_install
   local env_file="$INSTALL_DIR/.env"
   [ -f "$env_file" ] || die "Config missing: $env_file"
+  if ! config_complete "$env_file"; then
+    die "Config at $env_file is incomplete or contains template values. Edit it before running deploy."
+  fi
   local enabled_providers
   enabled_providers="$(sed -nE 's/^[[:space:]]*ENABLED_PROVIDERS[[:space:]]*=[[:space:]]*([^#[:space:]]+).*$/\1/p' "$env_file" | head -n1)"
   enabled_providers="${enabled_providers#\"}"; enabled_providers="${enabled_providers%\"}"

--- a/install.sh
+++ b/install.sh
@@ -147,7 +147,6 @@ install_release() {
   local tag="$1" tarball="$2"
   local staging
   staging="$(mktemp -d)"
-  trap 'rm -rf "$staging"' RETURN
   tar -xzf "$tarball" -C "$staging"
   local extracted
   extracted="$(find "$staging" -mindepth 1 -maxdepth 1 -type d | head -n1)"
@@ -181,6 +180,7 @@ install_release() {
     info "Migrated existing .env → $CONFIG_DIR/.env"
   fi
 
+  rm -rf "$staging"
   ok "Extracted release to $INSTALL_DIR"
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maestro-relay",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maestro-relay",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro-relay",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Maestro Relay — connect chat platforms (Discord today, Slack/Teams next) to Maestro AI agents via maestro-cli.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

Two follow-ups discovered during a fresh-install dry run of v0.1.0 in a sandboxed `\$HOME`.

- **`install.sh`** — drop the RETURN trap on `\$staging` cleanup, replace with explicit `rm -rf` at the end of `install_release()`. Bash's RETURN trap is process-wide, not function-local, so it kept firing on later function returns where `\$staging` had gone out of scope and printed `line 516: staging: unbound variable` *after* install completed.
- **`bin/maestro-relay-ctl.sh`** — \`cmd_deploy\` now mirrors \`install.sh\`'s \`config_complete\` check, refusing with a friendly error when the \`.env\` is empty or still has \`your_*\` template values. Previously it surfaced a Node stack trace (`Missing required env var: DISCORD_BOT_TOKEN`) to the user.

Bumps to \`0.1.1\` (patch).

## Test plan

- [x] \`npm test\` — 169/169 pass
- [x] Smoke-tested patched ctl deploy against the v0.1.0 install in \`/tmp/relay-fresh\`: now exits 1 with \`✗ Config at .../.env is incomplete or contains template values. Edit it before running deploy.\`
- [ ] After merge: tag \`v0.1.1\`, verify \`maestro-relay-v0.1.1.tar.gz\` published, re-run fresh-install dry run and confirm no \`unbound variable\` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deployment process with configuration validation to ensure all required Discord settings are present and properly configured. Users receive clear error messages if configuration is incomplete.

* **Chores**
  * Updated version to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->