### PR TITLE
fix(installer): hoist tarball var to script-global so EXIT trap is safe

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,7 @@ VERSION="${MAESTRO_RELAY_VERSION:-${MAESTRO_BRIDGE_VERSION:-${MAESTRO_DISCORD_VE
 MODULE="${MAESTRO_RELAY_MODULE:-${MAESTRO_BRIDGE_MODULE:-discord}}"
 NODE_MIN_MAJOR=22
 RELEASE_BACKUP=""
+RELEASE_TARBALL=""
 
 VOICE_FFMPEG=""
 VOICE_WHISPER=""
@@ -524,15 +525,15 @@ main() {
   check_node
   check_maestro_cli
 
-  local tag tarball
+  local tag
   tag="$(resolve_release)"
   info "Target release: ${tag}"
 
-  tarball="$(mktemp)"
-  trap 'rm -f "$tarball"' EXIT
-  download_release "$tag" "$tarball"
+  RELEASE_TARBALL="$(mktemp)"
+  trap 'rm -f "$RELEASE_TARBALL"' EXIT
+  download_release "$tag" "$RELEASE_TARBALL"
   trap 'rollback_install' ERR
-  install_release "$tag" "$tarball"
+  install_release "$tag" "$RELEASE_TARBALL"
   install_deps
   trap - ERR
   install_ctl

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maestro-relay",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maestro-relay",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro-relay",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Maestro Relay — connect chat platforms (Discord today, Slack/Teams next) to Maestro AI agents via maestro-cli.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

PR #33 fixed the RETURN-trap leak on `\$staging`. Re-running the v0.1.1 installer in a sandbox surfaces the **same scoping bug** on the EXIT trap for `\$tarball` — the local declaration is gone by the time the trap fires when `main` returns, and `set -u` prints `tarball: unbound variable` after "Install complete".

Promoting `tarball` to a script-global `RELEASE_TARBALL` alongside the existing `RELEASE_BACKUP` is the smallest fix that keeps both success and failure paths clean.

## Test plan

- [x] Pre-flight: ran patched `install.sh` in `/tmp/relay-fresh3`, install completes silently with no trailing warning
- [x] Existing tests still pass on `main` baseline (no test code touched)
- [ ] After merge: tag `v0.1.2`, run fresh-install dry-run against the published tarball, confirm no `unbound variable` warnings end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)