### PR TITLE
fix(installer,workflow): silence /dev/tty noise; bump action-gh-release to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           echo "checksum=${staging}.tar.gz.sha256" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |

--- a/install.sh
+++ b/install.sh
@@ -56,6 +56,13 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1${2:+ — $2}"
 }
 
+# Real try-open of /dev/tty. `[ -r /dev/tty ]` returns true in some
+# non-interactive contexts (e.g. `bash -c "$(curl ...)"`) where the
+# subsequent `</dev/tty` redirect then fails noisily.
+can_read_tty() {
+  { : </dev/tty; } 2>/dev/null
+}
+
 detect_os() {
   case "$(uname -s)" in
     Linux)  echo linux ;;
@@ -201,7 +208,7 @@ prompt_var() {
   [ -n "$default" ] && prompt="${prompt} [${default}]"
   prompt="${prompt}: "
   local value=""
-  if [ -r /dev/tty ]; then
+  if can_read_tty; then
     read -r -p "$prompt" value </dev/tty || true
   fi
   [ -z "$value" ] && value="$default"
@@ -218,7 +225,7 @@ write_config() {
   fi
 
   local interactive=0
-  [ -r /dev/tty ] && interactive=1
+  can_read_tty && interactive=1
   local have_required=0
   if [ -n "${DISCORD_BOT_TOKEN:-}" ] \
      && [ -n "${DISCORD_CLIENT_ID:-}" ] \
@@ -320,7 +327,7 @@ expand_tilde() {
 
 prompt_yes_no() {
   local prompt="$1" default="${2:-Y}" ans=""
-  [ -r /dev/tty ] || { printf '%s' "$default"; return; }
+  can_read_tty || { printf '%s' "$default"; return; }
   read -r -p "$prompt" ans </dev/tty || ans=""
   [ -z "$ans" ] && ans="$default"
   case "$ans" in
@@ -344,7 +351,7 @@ setup_voice_choose_model() {
     fi
   fi
 
-  if [ -r /dev/tty ]; then
+  if can_read_tty; then
     if [ "$(prompt_yes_no '  Already have a whisper model downloaded? [y/N] ' N)" = "Y" ]; then
       local input m
       while :; do
@@ -415,7 +422,7 @@ setup_voice() {
     enable=1
   elif [ "$voice_env" = "0" ]; then
     enable=0
-  elif [ -r /dev/tty ]; then
+  elif can_read_tty; then
     info "Configure voice transcription"
     if [ "$(prompt_yes_no '  Enable voice transcription? [Y/n] ' Y)" = "Y" ]; then
       enable=1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maestro-relay",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maestro-relay",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro-relay",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Maestro Relay — connect chat platforms (Discord today, Slack/Teams next) to Maestro AI agents via maestro-cli.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

Cosmetic patches found during the v0.1.2 fresh-install dry-run:

- **\`install.sh\`** — \`[ -r /dev/tty ]\` returns true in non-interactive contexts (e.g. \`bash -c \"\$(curl ...)\"\`) where /dev/tty exists but isn't actually openable. The subsequent \`</dev/tty\` redirect fails and prints \`environment: line N: /dev/tty: No such device or address\` to stderr. Replace with a real try-open helper \`can_read_tty\` that uses \`{ : </dev/tty; } 2>/dev/null\` to test true openability.
- **\`.github/workflows/release.yml\`** — bump \`softprops/action-gh-release\` from \`v2\` (Node 20, deprecated, forced upgrade by 2026-06-02) to \`v3\` (Node 24). Per upstream release notes, v3.0.0 is API-compatible — only the action runtime is bumped.

Bumps to \`0.1.3\` (patch).

## Test plan

- [x] \`npm test\` — 169/169 pass
- [x] Sandbox \`bash install.sh\` with no TTY: zero \`tty: No such\` warnings (verified via \`grep -c\`); installer correctly hits the \"Non-interactive shell — writing template\" branch
- [ ] After merge: tag \`v0.1.3\`, verify Release workflow runs cleanly with \`action-gh-release@v3\` and produces \`maestro-relay-v0.1.3.tar.gz\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release publishing workflow to v3
  * Version bumped to 0.1.3

* **Improvements**
  * Enhanced the installation script to better handle interactive prompts, improving behavior in both automated and manual setups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->