### PR TITLE
docs: split provider-specific docs out of README and add provider-dev guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ FFMPEG_PATH=ffmpeg                # optional: override ffmpeg executable path
 WHISPER_CLI_PATH=whisper-cli      # optional: override whisper-cli executable path
 # mkdir -p ./models && curl -L -o models/ggml-base.en.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
 WHISPER_MODEL_PATH=models/ggml-base.en.bin  # optional: whisper.cpp model path
+WHISPER_LANGUAGE=auto                       # optional: whisper language code, or 'auto' for detection
 
 # --- Discord provider (loaded only if 'discord' is in ENABLED_PROVIDERS) ---
 DISCORD_BOT_TOKEN=your_bot_token_here

--- a/AGENTS-providers.md
+++ b/AGENTS-providers.md
@@ -1,0 +1,181 @@
+# Provider development guide
+
+This document is the deep-dive companion to [`AGENTS.md`](AGENTS.md) (and [`docs/architecture.md`](docs/architecture.md)) for adding a new chat-platform provider to Maestro Relay. Everything below is what you'd need to know to ship a Slack, Teams, Matrix, etc. adapter without touching the kernel.
+
+If you're adding behavior to the existing Discord provider rather than building a new one, work in `src/providers/discord/` and consult [`docs/discord.md`](docs/discord.md) instead.
+
+## The kernel/provider boundary
+
+The kernel (`src/core/`) is provider-agnostic. It has zero `discord.js` (or any platform-SDK) imports, and it speaks only in three structured types:
+
+- `IncomingMessage` — what the provider hands to the kernel when a user sends a message.
+- `OutgoingMessage` — what the kernel hands back to the provider to post into chat.
+- `ChannelTarget` / `MessageTarget` — opaque-to-kernel pointers for "where to put this".
+
+The kernel owns:
+
+- Per-conversation FIFO queueing (`src/core/queue.ts`).
+- HTTP API for agent → chat pushes (`src/core/api.ts`, `POST /api/send`, `GET /api/health`).
+- SQLite registry of agent ↔ channel bindings, keyed `(provider, channel_id)` (`src/core/db/`).
+- `maestro-cli` invocation (`src/core/maestro.ts`).
+- Attachment download (`src/core/attachments.ts`) and voice transcription (`src/core/transcription.ts`).
+- Message splitting (`src/core/splitMessage.ts`) so providers don't reimplement chunking against per-platform message-length limits.
+
+The provider owns:
+
+- Connecting to the platform and translating its events into `IncomingMessage`.
+- Posting messages, reactions, and typing indicators back via `BridgeProvider.send` / `react` / `sendTyping`.
+- Resolving "this conversation maps to which agent + Maestro session" via `BridgeProvider.resolveConversation`.
+- Any platform-specific surface (slash commands, threads, voice flags, mentions).
+- Its own `<PROVIDER>_*` env vars and any provider-specific DB tables (named `<provider>_*`).
+
+## The `BridgeProvider` contract
+
+Defined in `src/core/types.ts`. Every provider exports a class implementing this:
+
+| Method                          | Required | Purpose                                                                              |
+| ------------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `start(ctx: KernelContext)`     | yes      | Connect to the platform, register event handlers, call `ctx.enqueue(msg)` per inbound message |
+| `stop()`                        | yes      | Disconnect cleanly; called on graceful shutdown                                      |
+| `resolveConversation(message)`  | yes      | Look up the maestro agent + session bound to this conversation; return null to drop  |
+| `send(target, msg)`             | yes      | Post a message into a channel/thread; called by the kernel queue                     |
+| `findOrCreateAgentChannel(id)`  | yes      | Look up or create the platform channel bound to an agent (used by `/api/send`)       |
+| `isReady()`                     | yes      | Provider readiness for `/api/health`                                                 |
+| `react?(target, emoji)`         | optional | Queue/transcription indicator (e.g. `⏳`, `🎧`)                                      |
+| `sendTyping?(target)`           | optional | Typing indicator while the agent thinks                                              |
+
+The kernel calls `react` and `sendTyping` if they exist; safe to omit when the platform has no analogue.
+
+### `KernelContext`
+
+What `start(ctx)` receives. Currently exposes:
+
+- `ctx.enqueue(msg: IncomingMessage, options?: EnqueueOptions)` — push a message into the per-conversation queue. `options.attachmentsOverride` lets the provider replace the attachment list (used by voice transcription to drop the audio file). `options.contentOverride` lets the provider rewrite the message content (used by voice transcription to inject the transcript).
+- `ctx.logger` — kernel-supplied error logger; provider should use this rather than `console.error` so logs land where the kernel expects.
+
+### `IncomingMessage`
+
+Provider → kernel (see `src/core/types.ts` for the source of truth):
+
+```ts
+{
+  provider: ProviderName;       // 'discord', 'slack', etc.
+  messageId: string;            // platform-native message ID
+  channelId: string;            // conversation id — equals threadId for thread messages, channelId otherwise
+  authorId: string;             // platform user ID of sender
+  authorName: string;           // display name (used in logs and outbound formatting)
+  content: string;              // raw text content
+  attachments: IncomingAttachment[];
+  isThread: boolean;            // true when the conversation is a sub-thread (Discord thread, Slack thread reply, etc.)
+  raw?: unknown;                // adapter-internal payload (raw SDK message, etc.) — opaque to the kernel
+}
+```
+
+`IncomingAttachment` is `{ url, name, size, contentType? }`. There's no kernel-level `isVoice` flag; voice handling is provider-driven (see "Voice transcription" below).
+
+### `OutgoingMessage`
+
+Kernel → provider:
+
+```ts
+{
+  text: string;
+  mention?: boolean;   // provider decides how to render (e.g. Discord: prepend <@DISCORD_MENTION_USER_ID>)
+}
+```
+
+The kernel splits long replies via `splitMessage` and calls `send` once per part; only the first part carries `mention=true` when requested.
+
+## Project layout convention
+
+All provider code lives under `src/providers/<name>/`. Mirror the Discord layout:
+
+```
+src/providers/<name>/
+├── adapter.ts          # The class implementing BridgeProvider
+├── config.ts           # Loads <PROVIDER>_* env vars (called lazily at start())
+├── messageCreate.ts    # Translates platform events → IncomingMessage
+├── channelsDb.ts       # provider='<name>'-bound wrapper around src/core/db
+├── deploy.ts           # (optional) Registers slash/app commands with the platform
+├── commands/           # (optional) Slash/app command handlers
+└── <other>.ts          # Anything else strictly platform-specific
+```
+
+Things to keep out of `src/core/`: SDK imports (`discord.js`, `@slack/bolt`, etc.), platform-specific types, slash-command schemas. The kernel should compile and pass tests with every provider directory deleted.
+
+## Hooking the provider in
+
+### 1. Register the adapter
+
+In `src/core/providers.ts`, add a `case` to `loadProvider`:
+
+```ts
+case 'slack':
+  const { SlackProvider } = await import('../providers/slack/adapter.js');
+  return new SlackProvider();
+```
+
+This is the only kernel file the provider should touch.
+
+### 2. Document env vars
+
+Add a section to `.env.example`:
+
+```env
+# --- Slack provider (loaded only if 'slack' is in ENABLED_PROVIDERS) ---
+SLACK_BOT_TOKEN=your_xoxb_token_here
+SLACK_APP_TOKEN=your_xapp_token_here
+SLACK_SIGNING_SECRET=your_signing_secret_here
+```
+
+Validate creds in `start(ctx)`, throwing a clear error if missing. Don't validate at module load — a disabled provider must not fail the bridge on missing env.
+
+### 3. DB tables
+
+Provider-specific tables go in `src/core/db/migrations.ts` with the naming convention `<provider>_<table>` (e.g. `discord_agent_threads`). Migrations are idempotent and run on first start.
+
+The shared `agent_channels` table is keyed on `(provider, channel_id)` — wrap it in a thin provider-bound module (see `src/providers/discord/channelsDb.ts` for the pattern) so call sites don't repeat the provider name.
+
+### 4. Installer module switch
+
+`install.sh` exposes `MAESTRO_RELAY_MODULE` for selecting an install-time provider. Today it only accepts `discord`. When adding a provider:
+
+- Update the `normalize_module` allow-list in `install.sh`.
+- Add provider-credential prompts to `write_config` (gated on the selected module).
+- Update `cmd_deploy` in `bin/maestro-relay-ctl.sh` to route to the right `dist/providers/<name>/deploy.js` based on `ENABLED_PROVIDERS`.
+
+Keep installer module selection aligned with runtime `ENABLED_PROVIDERS` and CLI `--provider` support.
+
+### 5. Documentation
+
+Add a `docs/<provider>.md` mirroring `docs/discord.md`'s structure: bot setup, configuration table, command surface, runtime behavior, security, troubleshooting. Link it from the README.
+
+## Testing
+
+- Unit-test the message translation (platform event → `IncomingMessage`) in isolation; don't pull in the platform SDK runtime in tests.
+- The kernel's tests (`src/__tests__/queue.test.ts`, `server.test.ts`, etc.) use `mockProvider.test.ts` as a reference for a minimal `BridgeProvider` implementation — copy that pattern when building a real adapter so the kernel tests stay provider-agnostic.
+- Run the full suite: `npm test` (169 tests at time of writing). All kernel tests should pass with your provider added.
+
+## Voice transcription
+
+If your platform has a "voice message" primitive (Discord's `IsVoiceMessage`, etc.), transcription is provider-driven but uses a kernel utility:
+
+1. In `messageCreate.ts`, detect the voice flag and pull the audio attachment out of the regular list.
+2. Optionally `react()` with `🎧` while transcription runs.
+3. Call `transcribeVoiceAttachment` from `src/core/transcription.ts` for each voice attachment.
+4. Enqueue the message with `contentOverride` set to the original text plus transcript, and `attachmentsOverride` set to the non-voice attachments so the kernel's queue skips the audio file.
+5. On transcription failure, fall back to forwarding the audio as a regular attachment with an error advisory.
+
+See `src/providers/discord/messageCreate.ts` for the canonical implementation, and [`docs/voice.md`](docs/voice.md) for runtime/setup details.
+
+## Checklist for shipping a new provider
+
+- [ ] `src/providers/<name>/adapter.ts` implements `BridgeProvider`
+- [ ] `loadProvider` in `src/core/providers.ts` recognizes `<name>`
+- [ ] `.env.example` documents `<PROVIDER>_*` keys
+- [ ] DB migrations (if any) named `<provider>_*` and idempotent
+- [ ] `install.sh` `normalize_module` allow-list includes `<name>`
+- [ ] `bin/maestro-relay-ctl.sh:cmd_deploy` routes to the new provider
+- [ ] `docs/<provider>.md` mirrors `docs/discord.md`
+- [ ] README's provider list updated
+- [ ] `npm test` green (kernel tests pass, plus provider-specific tests)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,15 +28,7 @@ This repo is **Maestro Relay** — a chat-platform-to-Maestro bridge built aroun
 
 ### Discord provider
 
-- `src/providers/discord/adapter.ts` — implements `BridgeProvider`
-- `src/providers/discord/messageCreate.ts` — Discord message → `IncomingMessage`
-- `src/providers/discord/voice.ts` — Discord voice-message detection
-- `src/providers/discord/commands/` — slash command handlers
-- `src/providers/discord/deploy.ts` — registers slash commands with Discord API
-- `src/providers/discord/channelsDb.ts` — `provider='discord'`-bound wrapper around the core channel registry
-- `src/providers/discord/threadsDb.ts` — Discord-only thread registry (`discord_agent_threads`)
-- `src/providers/discord/embed.ts` — Discord embed limit helpers
-- `src/providers/discord/config.ts` — `DISCORD_*` env loading
+Lives under `src/providers/discord/` (`adapter.ts`, `messageCreate.ts`, `voice.ts`, `commands/`, `deploy.ts`, `channelsDb.ts`, `threadsDb.ts`, `embed.ts`, `config.ts`). For Discord-specific runtime behavior, env vars, slash commands, and bot setup see [docs/discord.md](docs/discord.md). Voice transcription is documented in [docs/voice.md](docs/voice.md).
 
 ### CLI
 
@@ -56,10 +48,14 @@ Local API on `127.0.0.1:API_PORT` (default 3457). See [docs/api.md](docs/api.md)
 
 ## Adding a new provider
 
-1. Create `src/providers/<name>/adapter.ts` exporting a class that implements `BridgeProvider` from `src/core/types.ts`.
-2. Register the provider name in `src/core/providers.ts` (`loadProvider` switch).
-3. Add a section to `.env.example` for the provider's credentials.
-4. Provider modules own their own DB tables, command surface, and event handling; the kernel only sees `IncomingMessage` and calls back via `BridgeProvider.send` / `react` / `sendTyping`.
+See [AGENTS-providers.md](AGENTS-providers.md) (a.k.a. [CLAUDE-providers.md](CLAUDE-providers.md)) for the deep-dive guide: kernel/provider contract, file-layout convention, DB and env conventions, voice-transcription integration, and a shipping checklist.
+
+TL;DR:
+
+1. Implement `BridgeProvider` from `src/core/types.ts` at `src/providers/<name>/adapter.ts`.
+2. Add a `case` to `loadProvider` in `src/core/providers.ts`.
+3. Document `<PROVIDER>_*` env vars in `.env.example`.
+4. Add `docs/<name>.md` mirroring `docs/discord.md`'s structure.
 
 ## Installer module switch
 

--- a/CLAUDE-providers.md
+++ b/CLAUDE-providers.md
@@ -1,0 +1,1 @@
+AGENTS-providers.md

--- a/README.md
+++ b/README.md
@@ -67,25 +67,14 @@ npm install
 cp .env.example .env
 ```
 
-Set these values in `.env`:
+Set core values in `.env`:
 
 ```
-# Core
 ENABLED_PROVIDERS=discord    # comma-separated; default 'discord'
 API_PORT=3457                # optional, default 3457
-
-# Discord provider
-DISCORD_BOT_TOKEN=           # Bot token from Discord Developer Portal
-DISCORD_CLIENT_ID=           # Application ID from Discord Developer Portal
-DISCORD_GUILD_ID=            # Your server's ID (right-click server → Copy ID)
-DISCORD_ALLOWED_USER_IDS=123,456   # Optional: comma-separated allowed user IDs
-DISCORD_MENTION_USER_ID=     # Optional: user ID to @mention when --mention is used
-
-# Voice transcription (optional)
-FFMPEG_PATH=/opt/homebrew/bin/ffmpeg
-WHISPER_CLI_PATH=/opt/homebrew/bin/whisper-cli
-WHISPER_MODEL_PATH=models/ggml-base.en.bin
 ```
+
+Then fill in the provider-specific keys. The Discord provider needs `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID`, and `DISCORD_GUILD_ID` — see [docs/discord.md](docs/discord.md) for bot setup, the full env-var reference, and slash-command deployment. For optional voice transcription, see [docs/voice.md](docs/voice.md).
 
 3. Deploy slash commands (Discord):
 
@@ -104,55 +93,6 @@ Optional for source-based local CLI usage:
 ```bash
 npm link
 ```
-
-## Voice Transcription (optional)
-
-When a user posts a Discord **voice message** (the mic-button recording, not an arbitrary `.ogg` upload) in a session thread, the bridge transcribes the audio with `whisper.cpp` and forwards the transcript to the agent. The original `.ogg` is **not** sent to the agent — only the transcribed text — and a `🎧` reaction marks the message while transcription runs.
-
-If the dependencies below are missing, the bridge starts normally and voice messages are forwarded as plain attachments with a one-line advisory; no other functionality is affected.
-
-**Behavior notes:**
-
-- Only messages flagged `IsVoiceMessage` by Discord are transcribed. Bare `.ogg` file uploads are routed through the normal attachment path.
-- Voice attachments larger than 25 MB are rejected up-front (the per-channel queue would otherwise be blocked for several minutes of ffmpeg/whisper work).
-- Mixed messages (voice + image/file) are supported: the transcription is forwarded as text and the non-voice attachments are downloaded for the agent as usual.
-
-### Installation
-
-1. Install [ffmpeg](https://ffmpeg.org/) and [whisper-cli](https://github.com/ggerganov/whisper.cpp) so they're on your `PATH` **before** running the installer. macOS via Homebrew:
-
-```bash
-brew install ffmpeg whisper-cli
-```
-
-   On Linux/Windows, install ffmpeg via your package manager and either build `whisper-cli` from the [whisper.cpp](https://github.com/ggerganov/whisper.cpp) repo (then symlink the binary into `~/.local/bin`) or use [Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux).
-
-2. **Production install (curl one-liner)** — the installer detects `ffmpeg` + `whisper-cli` on `PATH` and asks whether to enable voice transcription. If you say yes, it asks whether you already have a `ggml-*.bin` model file — paste the absolute path to reuse it, or let it download `ggml-base.en.bin` (~142 MB) into `~/.local/share/maestro-relay/models/`. Resolved **absolute** paths are written into `~/.config/maestro-relay/.env`, so the systemd/launchd service finds them regardless of `PATH`.
-
-   Non-interactive escape hatches:
-
-   ```bash
-   MAESTRO_RELAY_VOICE=1 \
-   MAESTRO_RELAY_MODEL=/abs/path/to/ggml-base.en.bin \
-     bash -c "$(curl -fsSL https://raw.githubusercontent.com/RunMaestro/Maestro-Relay/main/install.sh)"
-   ```
-
-   `MAESTRO_RELAY_VOICE=0` opts out; omitting `MAESTRO_RELAY_MODEL` triggers the download.
-
-3. **Source install** (npm-based) — there's no wizard; download a model and set the paths yourself:
-
-```bash
-mkdir -p ./models
-curl -L -o models/ggml-base.en.bin \
-  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
-
-# in .env (use `which ffmpeg` / `which whisper-cli` to find absolute paths):
-FFMPEG_PATH=/usr/bin/ffmpeg
-WHISPER_CLI_PATH=/home/you/.local/bin/whisper-cli
-WHISPER_MODEL_PATH=models/ggml-base.en.bin
-```
-
-The bridge probes these at startup; any missing piece is logged as `⚠️ Transcription disabled: …` and transcription is skipped at runtime.
 
 ## Production run
 
@@ -173,29 +113,18 @@ Coverage:
 npm run build && node --test --experimental-test-coverage dist/__tests__/**/*.test.js
 ```
 
-## Slash commands (Discord)
+## Providers
 
-| Command                    | Description                                                   |
-| -------------------------- | ------------------------------------------------------------- |
-| `/health`                  | Verify Maestro CLI is installed and working                   |
-| `/agents list`             | Show all available agents                                     |
-| `/agents new <agent>`      | Create a dedicated channel for an agent (autocomplete)        |
-| `/agents show <agent>`     | Show an agent's stats and recent activity                     |
-| `/agents disconnect`       | (Run inside an agent channel) Remove and delete the channel   |
-| `/agents readonly on\|off` | Toggle read-only mode for the current agent channel           |
-| `/session new`             | Create a new owner-bound thread for the current agent channel |
-| `/session list`            | List session threads for the current agent channel            |
-| `/playbook list`           | List playbooks (optionally filter by agent)                   |
-| `/playbook show <id>`      | Show details for a playbook                                   |
-| `/playbook run <id>`       | Run a playbook and post the completion summary in-channel     |
-| `/auto-run start <doc>`    | Launch an Auto Run document for the current agent channel     |
-| `/gist`                    | Publish the current agent's session transcript as a GitHub gist |
-| `/notes synopsis`          | Post an AI-generated synopsis of recent activity              |
-| `/notes history`           | Post a unified history feed across agents                     |
+| Provider | Docs | Status |
+| -------- | ---- | ------ |
+| Discord  | [docs/discord.md](docs/discord.md) — bot setup, env vars, slash commands, runtime behavior | Built-in |
+| Slack / Teams / Matrix | [AGENTS-providers.md](AGENTS-providers.md) — provider development guide | Add your own |
+
+Optional voice transcription (whisper.cpp): [docs/voice.md](docs/voice.md).
 
 ## How it works
 
-Mention the bot or run `/session new` in an agent channel to create a thread, then chat — messages are queued and forwarded to the agent via `maestro-cli`. See [docs/architecture.md](docs/architecture.md) for the full message flow, the kernel/provider split, and how to add a new provider.
+Mention the bot or run `/session new` in an agent channel to create a thread, then chat — messages are queued and forwarded to the agent via `maestro-cli`. See [docs/architecture.md](docs/architecture.md) for the full message flow and kernel/provider split, and [AGENTS-providers.md](AGENTS-providers.md) for the provider-development guide.
 
 ## Agent → chat messaging
 
@@ -214,40 +143,3 @@ This project was renamed from `discord-maestro` / `Maestro-Discord`. To smooth u
 
 The bridge stores channel ↔ agent mappings in a local SQLite database at `maestro-bot.db`.
 Delete this file to reset all channel bindings.
-
-## Discord bot permissions
-
-Invite the bot with both `bot` and `applications.commands` scopes:
-
-```text
-https://discord.com/oauth2/authorize?client_id=<DISCORD_CLIENT_ID>&scope=bot+applications.commands&permissions=309237681232
-```
-
-This grants the following permissions:
-
-- Manage Channels — create and delete agent channels (`/agents new`, `/agents disconnect`)
-- View Channels
-- Send Messages
-- Attach Files — re-upload user attachments when forwarding to a session thread
-- Add Reactions — `⏳`/`🎧` queue and transcription indicators
-- Create Public Threads — owner-bound session threads
-- Send Messages in Threads
-
-Then enable **Message Content Intent** under Privileged Gateway Intents at:
-
-```text
-https://discord.com/developers/applications/<DISCORD_CLIENT_ID>/bot
-```
-
-Without this the bot will fail to connect with a "Used disallowed intents" error.
-
-## Security
-
-- Slash command access can be limited with `DISCORD_ALLOWED_USER_IDS`.
-- Mention-created and `/session new` threads are bound to a single owner.
-- In bound threads, non-owner messages are ignored without bot replies.
-
-## Troubleshooting
-
-- If `/health` fails, ensure `maestro-cli` is on your `PATH`.
-- If commands don’t appear, re-run `npm run deploy-commands` after updating your bot or application settings.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,4 @@ The schema upgrades on first start: legacy `agent_channels` (single-PK `channel_
 
 ## Adding a new provider
 
-1. Create `src/providers/<name>/adapter.ts` exporting a class implementing `BridgeProvider`.
-2. Add a `case '<name>'` branch to `loadProvider` in `src/core/providers.ts`.
-3. Document the provider's env vars in `.env.example`.
-4. Users opt in by setting `ENABLED_PROVIDERS=discord,<name>`.
+See [AGENTS-providers.md](../AGENTS-providers.md) (also linked as [CLAUDE-providers.md](../CLAUDE-providers.md)) for the full provider-development guide: kernel/provider contract, file-layout convention, DB and env conventions, voice-transcription integration, and a shipping checklist.

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -1,0 +1,100 @@
+# Discord provider
+
+The Discord provider is the default, in-the-box chat interface for Maestro Relay. This document covers everything Discord-specific: bot creation, permissions, slash commands, and runtime behavior. For the kernel/provider boundary, see [architecture.md](architecture.md). For voice transcription (currently Discord-only), see [voice.md](voice.md).
+
+## Bot setup
+
+1. Create an application at https://discord.com/developers/applications.
+2. Under **Bot**, generate a token — this becomes `DISCORD_BOT_TOKEN`.
+3. Invite the bot with both `bot` and `applications.commands` scopes:
+
+```text
+https://discord.com/oauth2/authorize?client_id=<DISCORD_CLIENT_ID>&scope=bot+applications.commands&permissions=309237681232
+```
+
+   The `309237681232` permissions integer grants:
+
+   - **Manage Channels** — create/delete agent channels (`/agents new`, `/agents disconnect`)
+   - **View Channels**
+   - **Send Messages**
+   - **Attach Files** — re-upload user attachments when forwarding to a session thread
+   - **Add Reactions** — `⏳` / `🎧` queue and transcription indicators
+   - **Create Public Threads** — owner-bound session threads
+   - **Send Messages in Threads**
+
+4. Enable **Message Content Intent** under Privileged Gateway Intents at:
+
+```text
+https://discord.com/developers/applications/<DISCORD_CLIENT_ID>/bot
+```
+
+   Without this the bot fails to connect with a *"Used disallowed intents"* error.
+
+## Configuration
+
+Discord provider keys read from `.env`:
+
+| Key                        | Required | Purpose                                                    |
+| -------------------------- | -------- | ---------------------------------------------------------- |
+| `DISCORD_BOT_TOKEN`        | yes      | Bot token from the Discord Developer Portal                |
+| `DISCORD_CLIENT_ID`        | yes      | Application ID from the Discord Developer Portal           |
+| `DISCORD_GUILD_ID`         | yes      | Server ID where slash commands are registered              |
+| `DISCORD_ALLOWED_USER_IDS` | no       | Comma-separated user IDs allowed to use slash commands     |
+| `DISCORD_MENTION_USER_ID`  | no       | User ID to `@mention` when API callers pass `mention=true` |
+
+The provider only loads if `discord` is in `ENABLED_PROVIDERS` (default: `discord`).
+
+## Slash commands
+
+| Command                    | Description                                                     |
+| -------------------------- | --------------------------------------------------------------- |
+| `/health`                  | Verify Maestro CLI is installed and working                     |
+| `/agents list`             | Show all available agents                                       |
+| `/agents new <agent>`      | Create a dedicated channel for an agent (autocomplete)          |
+| `/agents show <agent>`     | Show an agent's stats and recent activity                       |
+| `/agents disconnect`       | (Run inside an agent channel) Remove and delete the channel     |
+| `/agents readonly on\|off` | Toggle read-only mode for the current agent channel             |
+| `/session new`             | Create a new owner-bound thread for the current agent channel   |
+| `/session list`            | List session threads for the current agent channel              |
+| `/playbook list`           | List playbooks (optionally filter by agent)                     |
+| `/playbook show <id>`      | Show details for a playbook                                     |
+| `/playbook run <id>`       | Run a playbook and post the completion summary in-channel       |
+| `/auto-run start <doc>`    | Launch an Auto Run document for the current agent channel       |
+| `/gist`                    | Publish the current agent's session transcript as a GitHub gist |
+| `/notes synopsis`          | Post an AI-generated synopsis of recent activity                |
+| `/notes history`           | Post a unified history feed across agents                       |
+
+### Deploying slash commands
+
+The production install one-liner registers commands automatically. Re-run after changes via:
+
+```bash
+maestro-relay-ctl deploy
+```
+
+For source-based development:
+
+```bash
+npm run deploy-commands
+```
+
+## Runtime behavior
+
+- **Mentioning the bot** in an agent channel creates a new owner-bound thread (equivalent to running `/session new`).
+- **Owner-bound threads**: only the user who created the thread can trigger the agent. Other users' messages are silently ignored — no error reply, no forwarding.
+- **Read-only mode** via `/agents readonly on` lets the bridge POST agent updates to the channel (via the HTTP API) without forwarding user messages back. Toggle off with `/agents readonly off`.
+- **Reactions**: `⏳` while a message is queued, `🎧` while a voice message is being transcribed.
+- **Usage stats** are appended below each agent reply (tokens, cost, context %).
+
+## Security
+
+- Slash command access can be locked down with `DISCORD_ALLOWED_USER_IDS`.
+- Threads created by mention or `/session new` are bound to a single owner; non-owner messages are ignored silently.
+- The bot only auto-creates channels under the **Maestro Agents** category.
+
+## Troubleshooting
+
+- **`/health` fails** → ensure `maestro-cli` is on the relay's `PATH` and reachable.
+- **Slash commands don't appear** → re-run `maestro-relay-ctl deploy` (production) or `npm run deploy-commands` (source). Confirm the bot is in the guild specified by `DISCORD_GUILD_ID`.
+- **"Used disallowed intents"** at startup → enable Message Content Intent under Privileged Gateway Intents (see Bot setup, step 4).
+- **Bot is online but ignores messages** → check the channel is registered (`/agents list`), and that the message author is the thread owner (or no owner constraint applies for top-level agent channels).

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -1,0 +1,60 @@
+# Voice transcription
+
+Voice messages posted in agent channels are transcribed locally with [whisper.cpp](https://github.com/ggerganov/whisper.cpp) and forwarded to the agent as text. The original audio file is **not** sent to the agent — only the transcribed text — and a `🎧` reaction marks the message while transcription runs.
+
+If the dependencies below are missing, the bridge starts normally and voice messages fall through to the regular attachment path with a one-line advisory. No other functionality is affected.
+
+> **Provider scope**: today only the [Discord provider](discord.md) emits voice messages (via Discord's `IsVoiceMessage` flag). Future providers can opt in by mapping their own voice-flag attachments to `IncomingMessage.attachments[].isVoice` and reusing `src/core/transcription.ts`.
+
+## Behavior
+
+- Only messages flagged as voice by the platform (Discord: `IsVoiceMessage`) are transcribed. Bare `.ogg` uploads go through the normal attachment path.
+- Voice attachments larger than 25 MB are rejected up-front (the per-channel queue would otherwise be blocked for several minutes of ffmpeg/whisper work).
+- Mixed messages (voice + image/file) are supported: transcription is forwarded as text and non-voice attachments are downloaded for the agent as usual.
+
+## Setup — production install
+
+1. Install `ffmpeg` and `whisper-cli` on your `PATH` **before** running the installer:
+
+   - **macOS** (Homebrew): `brew install ffmpeg whisper-cli`
+   - **Linux/Windows**: install ffmpeg via your package manager; build whisper-cli from the [whisper.cpp](https://github.com/ggerganov/whisper.cpp) repo (then symlink the binary into `~/.local/bin`) or use [Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux).
+
+2. Run the installer one-liner. It detects both binaries on `PATH` and asks whether to enable voice. If you say yes, it asks whether you already have a `ggml-*.bin` model — paste the absolute path to reuse it, or let it download `ggml-base.en.bin` (~142 MB) into `~/.local/share/maestro-relay/models/`.
+
+   Resolved **absolute** paths are written into `~/.config/maestro-relay/.env` so the systemd/launchd service finds them regardless of `PATH`.
+
+3. Non-interactive escape hatches:
+
+```bash
+MAESTRO_RELAY_VOICE=1 \
+MAESTRO_RELAY_MODEL=/abs/path/to/ggml-base.en.bin \
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/RunMaestro/Maestro-Relay/main/install.sh)"
+```
+
+   `MAESTRO_RELAY_VOICE=0` opts out; omitting `MAESTRO_RELAY_MODEL` triggers the download.
+
+## Setup — source install
+
+There's no wizard. Download a model and set the paths yourself:
+
+```bash
+mkdir -p ./models
+curl -L -o models/ggml-base.en.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
+
+# in .env (use `which ffmpeg` / `which whisper-cli` for absolute paths):
+FFMPEG_PATH=/usr/bin/ffmpeg
+WHISPER_CLI_PATH=/home/you/.local/bin/whisper-cli
+WHISPER_MODEL_PATH=models/ggml-base.en.bin
+```
+
+## Configuration
+
+| Key                  | Default                     | Purpose                                          |
+| -------------------- | --------------------------- | ------------------------------------------------ |
+| `FFMPEG_PATH`        | `ffmpeg`                    | Path to ffmpeg binary                            |
+| `WHISPER_CLI_PATH`   | `whisper-cli`               | Path to whisper-cli binary                       |
+| `WHISPER_MODEL_PATH` | `models/ggml-base.en.bin`   | Path to a whisper `.bin` model                   |
+| `WHISPER_LANGUAGE`   | `auto`                      | Whisper language code, or `auto` for detection   |
+
+The bridge probes these at startup; any missing piece is logged as `⚠️ Transcription disabled: …` and transcription is skipped at runtime.


### PR DESCRIPTION
## Summary

The README had grown to ~250 lines mixing kernel-level info with three big chunks of Discord/voice/whisper-specific detail. New file structure:

| New file                | Contents                                                                                              |
| ----------------------- | ----------------------------------------------------------------------------------------------------- |
| \`docs/discord.md\`       | Bot setup, OAuth invite URL + permissions integer, full \`DISCORD_*\` env table, slash commands, runtime behavior, security, troubleshooting |
| \`docs/voice.md\`         | whisper.cpp setup (production + source flows), behavior notes, config table incl. the previously-undocumented \`WHISPER_LANGUAGE\` |
| \`AGENTS-providers.md\` (+ \`CLAUDE-providers.md\` symlink) | Deep-dive provider-development guide: \`BridgeProvider\` contract, \`IncomingMessage\` / \`OutgoingMessage\` / \`KernelContext\` shapes verified against \`src/core/types.ts\`, file-layout convention, DB/env conventions, voice-transcription integration pattern, shipping checklist |

Refactored existing files:

- \`README.md\` — replaced inline Discord/voice/permissions sections with a Providers table and links. Kept kernel-agnostic content (install, build, tests, migration, data storage).
- \`AGENTS.md\` — slimmed the Discord-provider file list to a one-liner pointing at \`docs/discord.md\`, replaced the 4-bullet "Adding a new provider" with a TL;DR + link to \`AGENTS-providers.md\`.
- \`docs/architecture.md\` — replaced its duplicate "Adding a new provider" section with a link to \`AGENTS-providers.md\` (single source of truth).
- \`.env.example\` — added \`WHISPER_LANGUAGE\` for parity with \`voice.md\` (was already read by \`src/core/config.ts\`, just wasn't documented).

No code changes; no version bump.

## Test plan

- [x] All internal markdown links resolve (manually verified all \`*.md\` link targets exist)
- [x] Type signatures in \`AGENTS-providers.md\` cross-checked against \`src/core/types.ts\` (\`IncomingMessage\`, \`OutgoingMessage\`, \`IncomingAttachment\`, \`KernelContext\`, \`EnqueueOptions\`)
- [x] Voice-transcription flow in \`AGENTS-providers.md\` cross-checked against \`src/providers/discord/messageCreate.ts\` (\`contentOverride\` + \`attachmentsOverride\` pattern)
- [x] CI: lint+test+CodeRabbit on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)