### PR TITLE
fix: avoid leaking internal errors and normalize installer provider parsing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -307,6 +307,8 @@ config_complete() {
   [ -f "$file" ] || return 1
   local enabled_module
   enabled_module="$(sed -nE 's/^[[:space:]]*ENABLED_PROVIDERS[[:space:]]*=[[:space:]]*([^#[:space:]]+).*/\1/p' "$file" | head -n1)"
+  enabled_module="${enabled_module#\"}"; enabled_module="${enabled_module%\"}"
+  enabled_module="${enabled_module#\'}"; enabled_module="${enabled_module%\'}"
   local required_keys
   if [ "$enabled_module" = "slack" ]; then
     required_keys="SLACK_BOT_TOKEN SLACK_SIGNING_SECRET SLACK_TEAM_ID SLACK_APP_ID"

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -203,7 +203,7 @@ export function createQueue(deps: QueueDeps) {
           `agent=${conv.agentId} session=${conv.sessionId ?? 'new'} channel=${message.channelId} error=${rawError}`,
         );
         await provider.send(target, {
-          text: `⚠️ The agent could not complete this request.${hint}\n-# 🔧 ${rawError}`,
+          text: `⚠️ The agent could not complete this request.${hint}`,
         });
       }
 
@@ -227,7 +227,7 @@ export function createQueue(deps: QueueDeps) {
         `agent=${conv.agentId} session=${conv.sessionId ?? 'new'} channel=${message.channelId} error=${errMsg}`,
       );
       await provider.send(target, {
-        text: `❌ Failed to get response from agent:\n\`\`\`\n${errMsg}\n\`\`\``,
+        text: '❌ Failed to get response from agent. Check relay logs for details.',
       });
     }
 


### PR DESCRIPTION
## Summary
- stop surfacing raw internal agent/exception details to chat users in queue error paths
- normalize quoted ENABLED_PROVIDERS in installer config_complete so Slack/Discord key validation works with quoted env values

## Why
- keeps internal failure details in logs only
- fixes false negatives when .env uses quoted provider values (example: ENABLED_PROVIDERS="slack")

## Validation
- npm run build