### PR TITLE
fix(installer): set PATH on systemd unit and launchd plist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -534,10 +534,14 @@ install_service_linux() {
   mkdir -p "$unit_dir"
   local template="$INSTALL_DIR/templates/maestro-relay.service"
   [ -f "$template" ] || { warn "Service template missing at $template"; return; }
+  local node_bin; node_bin="$(command -v node)"
+  local node_dir; node_dir="$(dirname "$node_bin")"
   sed \
     -e "s|@INSTALL_DIR@|$INSTALL_DIR|g" \
     -e "s|@CONFIG_DIR@|$CONFIG_DIR|g" \
-    -e "s|@NODE_BIN@|$(command -v node)|g" \
+    -e "s|@NODE_BIN@|$node_bin|g" \
+    -e "s|@NODE_DIR@|$node_dir|g" \
+    -e "s|@HOME@|$HOME|g" \
     "$template" > "$unit_dir/maestro-relay.service"
   # Disable+remove a legacy maestro-discord unit if present so we don't leave
   # two competing user services running on upgrade.
@@ -563,10 +567,14 @@ install_service_macos() {
   mkdir -p "$INSTALL_DIR/logs"
   local template="$INSTALL_DIR/templates/sh.maestro.relay.plist"
   [ -f "$template" ] || { warn "Plist template missing at $template"; return; }
+  local node_bin; node_bin="$(command -v node)"
+  local node_dir; node_dir="$(dirname "$node_bin")"
   sed \
     -e "s|@INSTALL_DIR@|$INSTALL_DIR|g" \
     -e "s|@CONFIG_DIR@|$CONFIG_DIR|g" \
-    -e "s|@NODE_BIN@|$(command -v node)|g" \
+    -e "s|@NODE_BIN@|$node_bin|g" \
+    -e "s|@NODE_DIR@|$node_dir|g" \
+    -e "s|@HOME@|$HOME|g" \
     "$template" > "$plist_dir/sh.maestro.relay.plist"
   # Unload+remove a legacy launchd plist if present.
   if [ -f "$plist_dir/sh.maestro.discord.plist" ]; then

--- a/templates/maestro-relay.service
+++ b/templates/maestro-relay.service
@@ -9,6 +9,7 @@ StartLimitBurst=5
 Type=simple
 WorkingDirectory=@INSTALL_DIR@
 EnvironmentFile=@CONFIG_DIR@/.env
+Environment=PATH=@HOME@/.local/bin:@NODE_DIR@:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStart=@NODE_BIN@ @INSTALL_DIR@/dist/index.js
 Restart=on-failure
 RestartSec=5

--- a/templates/sh.maestro.relay.plist
+++ b/templates/sh.maestro.relay.plist
@@ -10,7 +10,7 @@
   <array>
     <string>/bin/bash</string>
     <string>-c</string>
-    <string>set -a; . "@CONFIG_DIR@/.env"; set +a; export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin${PATH:+:$PATH}"; exec "@NODE_BIN@" "@INSTALL_DIR@/dist/index.js"</string>
+    <string>set -a; . "@CONFIG_DIR@/.env"; set +a; export PATH="@HOME@/.local/bin:@NODE_DIR@:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin${PATH:+:$PATH}"; exec "@NODE_BIN@" "@INSTALL_DIR@/dist/index.js"</string>
   </array>
   <key>RunAtLoad</key>
   <true/>


### PR DESCRIPTION
## Summary

- Service-managed `maestro-relay` (systemd user unit / launchd plist) inherits a minimal PATH that resolves `maestro-cli` to the older `/usr/local/bin/maestro-cli` shim (which calls bare `node` and fails with exit 127 when node isn't on PATH) instead of the newer `~/.local/bin/maestro-cli` Electron-backed shim that has no node-on-PATH dependency.
- Bake a sane PATH into both `templates/maestro-relay.service` and `templates/sh.maestro.relay.plist` with `$HOME/.local/bin` and the node bin directory ahead of system paths, so the user-mode Maestro CLI shim wins and the legacy shim's bare `node` call still resolves as a fallback.
- `install.sh` now derives `@HOME@` and `@NODE_DIR@` from `$HOME` and `dirname $(command -v node)` and substitutes them in both templates.

## Why

Reported in production: relay running under `systemctl --user` would emit `[maestro-cli send] exit code: 127 | stderr: /usr/local/bin/maestro-cli: line 2: node: command not found` on every message. Root cause is that the systemd unit had no `Environment=PATH=…`, so the relay's spawned `maestro-cli` resolved to the wrong shim. The newer Maestro desktop already ships a PATH-resilient shim to `~/.local/bin/maestro-cli`; the relay just needs PATH to include that directory.

## Rendered output (example)

```
# systemd unit
Environment=PATH=/home/<user>/.local/bin:/home/<user>/.nvm/versions/node/v22.22.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

```
# launchd plist
export PATH="/Users/<user>/.local/bin:<node-dir>:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin${PATH:+:$PATH}"
```

## Test plan

- [ ] Re-run `install.sh` on a Linux box; confirm `~/.config/systemd/user/maestro-relay.service` contains the new `Environment=PATH=…` line with the user's actual `$HOME` and node bin dir substituted in.
- [ ] After `systemctl --user daemon-reload && systemctl --user restart maestro-relay`, inspect the running process env (`tr '\0' '\n' < /proc/$(systemctl --user show maestro-relay -p MainPID --value)/environ | grep PATH`) and confirm `~/.local/bin` is first.
- [ ] Verify `maestro-cli --version` resolves to `~/.local/bin/maestro-cli` under that PATH (Electron-shim, no `node: command not found`).
- [ ] Send a Discord mention to a connected agent and confirm the relay no longer logs `[maestro-cli send] exit code: 127`.
- [ ] On macOS: re-run `install.sh`, reload the LaunchAgent, and confirm the plist now exports the augmented PATH and the relay can spawn `maestro-cli` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved installation process to reliably compute and apply Node.js executable paths during setup.
  * Enhanced service configuration for Linux and macOS to ensure proper binary discovery and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->