### PR TITLE
feat(installer): opt-in RC release channel for installer + updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+          # Tags carrying a prerelease component (e.g. v0.5.0-rc.1) are published
+          # as GitHub prereleases so the stable "latest" endpoint keeps returning
+          # the last stable release. RC-channel installs opt into them explicitly.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             ${{ steps.package.outputs.tarball }}
             ${{ steps.package.outputs.checksum }}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ maestro-relay-ctl uninstall # remove install + service files
 Override any of these with `MAESTRO_RELAY_HOME`, `XDG_CONFIG_HOME`, or `MAESTRO_RELAY_BIN_DIR`. Pin a specific version with `MAESTRO_RELAY_VERSION=v1.0.0`.
 Choose a provider module at install time via `MAESTRO_RELAY_MODULE` (`discord` or `slack`).
 
+### Release channels (stable vs RC)
+
+The installer and `maestro-relay-ctl update` track the **stable** channel by default — the latest non-prerelease GitHub release. To try release candidates ahead of a stable cut, opt into the **rc** channel:
+
+```bash
+maestro-relay-ctl channel rc      # persist the preference, then:
+maestro-relay-ctl update          # pulls the newest release, prereleases included
+maestro-relay-ctl update --rc     # …or switch + update in one step
+maestro-relay-ctl channel stable  # switch back (or: update --stable)
+```
+
+For a fresh install on the RC channel, set the env var:
+
+```bash
+MAESTRO_RELAY_CHANNEL=rc bash -c "$(curl -fsSL https://raw.githubusercontent.com/RunMaestro/Maestro-Relay/main/install.sh)"
+```
+
+RC builds are published as GitHub **prereleases** (tags like `v0.5.0-rc.1`), so the stable channel never picks them up. Pin an exact build with `MAESTRO_RELAY_VERSION=vX.Y.Z-rc.N`. The persisted channel lives at `~/.config/maestro-relay/channel`.
+
 ## Install (development from source)
 
 1. Clone and install:

--- a/bin/maestro-relay-ctl.sh
+++ b/bin/maestro-relay-ctl.sh
@@ -48,23 +48,37 @@ LEGACY_LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LEGACY_LAUNCHD_LABEL}.plist"
 die() { printf '✗ %s\n' "$*" >&2; exit 1; }
 info() { printf '==> %s\n' "$*"; }
 
-# Resolve the active update channel: explicit env override > persisted file >
-# 'stable' default.
-resolve_channel() {
-  if [ -n "${MAESTRO_RELAY_CHANNEL:-}" ]; then
-    printf '%s' "$MAESTRO_RELAY_CHANNEL"
-  elif [ -f "$CHANNEL_FILE" ]; then
-    head -n1 "$CHANNEL_FILE" | tr -d '[:space:]'
-  else
-    printf 'stable'
-  fi
-}
-
-persist_channel() {
+validate_channel() {
   case "$1" in
     stable|rc) ;;
     *) die "Invalid channel: $1 (expected 'stable' or 'rc')" ;;
   esac
+}
+
+# Resolve the active update channel: explicit env override > persisted file >
+# 'stable' default. An unrecognized value (typo, stale file) is normalized to
+# 'stable' with a warning, so the reported channel and the actual behavior never
+# diverge. (resolve_channel runs inside $(...), where a die would only abort the
+# subshell — so it normalizes rather than exits; explicit sets still hard-fail
+# via persist_channel.)
+resolve_channel() {
+  local channel
+  if [ -n "${MAESTRO_RELAY_CHANNEL:-}" ]; then
+    channel="$MAESTRO_RELAY_CHANNEL"
+  elif [ -f "$CHANNEL_FILE" ]; then
+    channel="$(head -n1 "$CHANNEL_FILE" | tr -d '[:space:]')"
+  else
+    channel="stable"
+  fi
+  case "$channel" in
+    stable|rc) ;;
+    *) printf '⚠ Unknown update channel %q; using stable.\n' "$channel" >&2; channel="stable" ;;
+  esac
+  printf '%s' "$channel"
+}
+
+persist_channel() {
+  validate_channel "$1"
   mkdir -p "$CONFIG_DIR"
   printf '%s\n' "$1" > "$CHANNEL_FILE"
 }
@@ -223,16 +237,23 @@ cmd_update() {
     channel="$(resolve_channel)"
   fi
 
-  if [ "$channel" = "rc" ]; then
-    # Newest release including prereleases (the /releases list is newest-first).
-    api="https://api.github.com/repos/${REPO}/releases?per_page=20"
+  if [ -n "${MAESTRO_RELAY_VERSION:-}" ]; then
+    # An explicit version pin wins over channel resolution, preserving the
+    # documented `MAESTRO_RELAY_VERSION=vX.Y.Z[-rc.N] … update` path.
+    tag="$MAESTRO_RELAY_VERSION"
+    info "Re-running installer to pull pinned ${tag}"
   else
-    api="https://api.github.com/repos/${REPO}/releases/latest"
+    if [ "$channel" = "rc" ]; then
+      # Newest release including prereleases (the /releases list is newest-first).
+      api="https://api.github.com/repos/${REPO}/releases?per_page=20"
+    else
+      api="https://api.github.com/repos/${REPO}/releases/latest"
+    fi
+    tag="$(curl -fsSL "$api" | sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n1)"
+    [ -n "$tag" ] || die "Could not resolve a release tag on the '${channel}' channel"
+    info "Re-running installer to pull ${tag} (channel: ${channel})"
   fi
-  tag="$(curl -fsSL "$api" | sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n1)"
-  [ -n "$tag" ] || die "Could not resolve a release tag on the '${channel}' channel"
 
-  info "Re-running installer to pull ${tag} (channel: ${channel})"
   config_parent="$(dirname "$CONFIG_DIR")"
   curl -fsSL "https://raw.githubusercontent.com/${REPO}/${tag}/install.sh" \
     | env \

--- a/bin/maestro-relay-ctl.sh
+++ b/bin/maestro-relay-ctl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Service wrapper for the Maestro Relay.
-# Subcommands: start | stop | restart | status | logs | deploy | update | uninstall | version
+# Subcommands: start | stop | restart | status | logs | deploy | update | channel | uninstall | version
 #
 # Backwards-compat: legacy MAESTRO_BRIDGE_* / MAESTRO_DISCORD_* env vars are accepted as fallback.
 # A legacy install at ~/.local/share/maestro-bridge or ~/.local/share/maestro-discord is auto-detected when
@@ -35,6 +35,8 @@ fi
 
 BIN_DIR="${MAESTRO_RELAY_BIN_DIR:-${MAESTRO_BRIDGE_BIN_DIR:-${MAESTRO_DISCORD_BIN_DIR:-$HOME/.local/bin}}}"
 REPO="${MAESTRO_RELAY_REPO:-${MAESTRO_BRIDGE_REPO:-${MAESTRO_DISCORD_REPO:-RunMaestro/Maestro-Relay}}}"
+# Persisted update-channel preference (stable|rc); see cmd_channel / cmd_update.
+CHANNEL_FILE="$CONFIG_DIR/channel"
 SERVICE_NAME="maestro-relay"
 LAUNCHD_LABEL="sh.maestro.relay"
 LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
@@ -45,6 +47,27 @@ LEGACY_LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LEGACY_LAUNCHD_LABEL}.plist"
 
 die() { printf '✗ %s\n' "$*" >&2; exit 1; }
 info() { printf '==> %s\n' "$*"; }
+
+# Resolve the active update channel: explicit env override > persisted file >
+# 'stable' default.
+resolve_channel() {
+  if [ -n "${MAESTRO_RELAY_CHANNEL:-}" ]; then
+    printf '%s' "$MAESTRO_RELAY_CHANNEL"
+  elif [ -f "$CHANNEL_FILE" ]; then
+    head -n1 "$CHANNEL_FILE" | tr -d '[:space:]'
+  else
+    printf 'stable'
+  fi
+}
+
+persist_channel() {
+  case "$1" in
+    stable|rc) ;;
+    *) die "Invalid channel: $1 (expected 'stable' or 'rc')" ;;
+  esac
+  mkdir -p "$CONFIG_DIR"
+  printf '%s\n' "$1" > "$CHANNEL_FILE"
+}
 
 detect_os() {
   case "$(uname -s)" in
@@ -68,7 +91,8 @@ Commands:
   status      Show service status
   logs        Tail service logs (Ctrl+C to stop)
   deploy      Deploy slash commands to Discord
-  update      Reinstall the latest release (preserves config)
+  update      Reinstall the latest release (preserves config); pass --rc / --stable to pick the channel
+  channel     Show the update channel, or set it: 'channel rc' | 'channel stable'
   uninstall   Remove the relay, service files, and CLI symlinks
   version     Print installed version
 
@@ -76,6 +100,7 @@ Environment:
   MAESTRO_RELAY_HOME    Override install dir  (default: ~/.local/share/maestro-relay)
   XDG_CONFIG_HOME        Config dir parent     (default: ~/.config)
   MAESTRO_RELAY_MODULE   Installer-time module selection (currently: discord)
+  MAESTRO_RELAY_CHANNEL  Update channel: 'stable' (default) or 'rc' (release candidates)
   MAESTRO_BRIDGE_HOME    Accepted as fallback for back-compat
   MAESTRO_DISCORD_HOME   Accepted as fallback for back-compat with v0.0.x
 EOF
@@ -183,18 +208,51 @@ cmd_deploy() {
 }
 
 cmd_update() {
-  info "Re-running installer to pull the latest release"
-  local tag config_parent
-  tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n1)"
-  [ -n "$tag" ] || die "Could not resolve latest release tag"
+  local channel="" tag config_parent api
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --rc)     channel="rc" ;;
+      --stable) channel="stable" ;;
+      *) die "Unknown flag for update: $1 (expected --rc or --stable)" ;;
+    esac
+    shift
+  done
+  if [ -n "$channel" ]; then
+    persist_channel "$channel"
+  else
+    channel="$(resolve_channel)"
+  fi
+
+  if [ "$channel" = "rc" ]; then
+    # Newest release including prereleases (the /releases list is newest-first).
+    api="https://api.github.com/repos/${REPO}/releases?per_page=20"
+  else
+    api="https://api.github.com/repos/${REPO}/releases/latest"
+  fi
+  tag="$(curl -fsSL "$api" | sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n1)"
+  [ -n "$tag" ] || die "Could not resolve a release tag on the '${channel}' channel"
+
+  info "Re-running installer to pull ${tag} (channel: ${channel})"
   config_parent="$(dirname "$CONFIG_DIR")"
   curl -fsSL "https://raw.githubusercontent.com/${REPO}/${tag}/install.sh" \
     | env \
         MAESTRO_RELAY_HOME="$INSTALL_DIR" \
         MAESTRO_RELAY_BIN_DIR="$BIN_DIR" \
         MAESTRO_RELAY_REPO="$REPO" \
+        MAESTRO_RELAY_VERSION="$tag" \
+        MAESTRO_RELAY_CHANNEL="$channel" \
         XDG_CONFIG_HOME="$config_parent" \
         bash
+}
+
+cmd_channel() {
+  local arg="${1:-}"
+  if [ -z "$arg" ]; then
+    info "Update channel: $(resolve_channel)"
+    return
+  fi
+  persist_channel "$arg"
+  info "Update channel set to '$arg'. Run 'maestro-relay-ctl update' to apply."
 }
 
 cmd_uninstall() {
@@ -257,7 +315,8 @@ main() {
     status)    cmd_status ;;
     logs)      cmd_logs ;;
     deploy)    cmd_deploy ;;
-    update)    cmd_update ;;
+    update)    shift; cmd_update "$@" ;;
+    channel)   shift; cmd_channel "$@" ;;
     uninstall) cmd_uninstall ;;
     version)   cmd_version ;;
     -h|--help|help|"") usage ;;

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,10 @@ elif [ ! -d "$CONFIG_DIR" ] && [ -d "${XDG_CONFIG_HOME:-$HOME/.config}/maestro-d
 fi
 BIN_DIR="${MAESTRO_RELAY_BIN_DIR:-${MAESTRO_BRIDGE_BIN_DIR:-${MAESTRO_DISCORD_BIN_DIR:-$HOME/.local/bin}}}"
 VERSION="${MAESTRO_RELAY_VERSION:-${MAESTRO_BRIDGE_VERSION:-${MAESTRO_DISCORD_VERSION:-latest}}}"
+# Release channel: 'stable' (default) installs the latest non-prerelease GitHub
+# release; 'rc' installs the newest release *including* prereleases (release
+# candidates). Ignored when MAESTRO_RELAY_VERSION pins an explicit tag.
+CHANNEL="${MAESTRO_RELAY_CHANNEL:-stable}"
 MODULE="${MAESTRO_RELAY_MODULE:-${MAESTRO_BRIDGE_MODULE:-discord}}"
 NODE_MIN_MAJOR=22
 RELEASE_BACKUP=""
@@ -103,10 +107,17 @@ normalize_module() {
 
 resolve_release() {
   local api_url tag
-  if [ "$VERSION" = "latest" ]; then
-    api_url="https://api.github.com/repos/${REPO}/releases/latest"
-  else
+  if [ "$VERSION" != "latest" ]; then
+    # An explicit tag pin takes precedence over the channel.
     api_url="https://api.github.com/repos/${REPO}/releases/tags/${VERSION}"
+  elif [ "$CHANNEL" = "rc" ]; then
+    # RC channel: newest release *including* prereleases. The /releases list is
+    # returned newest-first, so the first tag_name is the most recently published
+    # release — a release-candidate or stable, whichever is newer.
+    api_url="https://api.github.com/repos/${REPO}/releases?per_page=20"
+  else
+    # Stable channel: GitHub's "latest" endpoint excludes prereleases.
+    api_url="https://api.github.com/repos/${REPO}/releases/latest"
   fi
   tag="$(curl -fsSL "$api_url" | sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n1)"
   [ -n "$tag" ] || die "Could not resolve release tag from ${api_url}"

--- a/install.sh
+++ b/install.sh
@@ -614,6 +614,11 @@ main() {
   echo
   echo
 
+  case "$CHANNEL" in
+    stable|rc) ;;
+    *) die "Invalid MAESTRO_RELAY_CHANNEL: '$CHANNEL' (expected 'stable' or 'rc')" ;;
+  esac
+
   require_cmd curl
   require_cmd tar
   require_cmd sed
@@ -635,6 +640,10 @@ main() {
   install_cli
   setup_voice
   write_config
+  # Record the active release channel so `maestro-relay-ctl update` keeps tracking
+  # it (stable or rc) without re-exporting MAESTRO_RELAY_CHANNEL on every update.
+  mkdir -p "$CONFIG_DIR"
+  printf '%s\n' "$CHANNEL" > "$CONFIG_DIR/channel"
   deploy_commands
   install_service
 


### PR DESCRIPTION
## Opt-in RC release channel (installer + updater)

Lets users track **release candidates** without leaving the stable line, so RC builds cut from `rc` can be dogfooded before a stable promotion.

### Changes
- **`.github/workflows/release.yml`** — tags carrying a prerelease component (e.g. `v0.5.0-rc.1`) are published as GitHub **prereleases** (`prerelease: ${{ contains(github.ref_name, '-') }}`). The stable `/releases/latest` endpoint keeps returning the last stable release, so existing users are unaffected.
- **`install.sh`** — new `MAESTRO_RELAY_CHANNEL` (`stable` default | `rc`). On `rc`, `resolve_release` picks the newest release **including** prereleases (via `/releases`, newest-first) instead of `/releases/latest`. An explicit `MAESTRO_RELAY_VERSION` pin still takes precedence.
- **`bin/maestro-relay-ctl.sh`** — `update --rc` / `update --stable`, plus a new `channel` subcommand. The preference persists at `$CONFIG_DIR/channel`; `update` now pins the resolved tag (`MAESTRO_RELAY_VERSION=$tag`) and forwards the channel to the installer. Precedence: env override → persisted file → `stable`.
- **README** — documents the stable-vs-RC workflow.

### Usage
```bash
maestro-relay-ctl channel rc      # persist, then `update`
maestro-relay-ctl update --rc     # switch + update in one step
maestro-relay-ctl channel stable  # switch back
MAESTRO_RELAY_CHANNEL=rc bash -c "$(curl -fsSL .../install.sh)"   # fresh RC install
```

### Verification
- `bash -n` clean on `install.sh` and `maestro-relay-ctl.sh`
- `channel` set/read/env-override/reject smoke-tested
- `release.yml` parses as valid YAML
- No application code changed (shell/yaml/docs only)

### Follow-up (not in this PR)
To actually cut the first RC from `rc`, the **same `release.yml` prerelease change must also exist on the `rc` branch** (that's where RC tags are built), and `rc`'s `package.json` version bumped to `X.Y.Z-rc.N`. Happy to open that as a separate `rc`-targeted change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for release channels, letting users choose between **stable** and **rc** updates.
  * Introduced a new command to view or switch the active channel, with optional persistent selection.

* **Bug Fixes**
  * Prerelease tags are now published as GitHub prereleases, so stable updates won’t pull them accidentally.
  * Update behavior now correctly respects a pinned version when one is specified.

* **Documentation**
  * Expanded the quick start guide with release-channel usage, including how to opt into RC builds and pin a specific RC version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->