### PR TITLE
feat(installer): bring channel-aware installer/updater onto rc (cherry-pick #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ maestro-relay-ctl uninstall # remove install + service files
 Override any of these with `MAESTRO_RELAY_HOME`, `XDG_CONFIG_HOME`, or `MAESTRO_RELAY_BIN_DIR`. Pin a specific version with `MAESTRO_RELAY_VERSION=v1.0.0`.
 Choose a provider module at install time via `MAESTRO_RELAY_MODULE` (`discord`, `slack`, `telegram`, or `teams`).
 
+### Release channels (stable vs RC)
+
+The installer and `maestro-relay-ctl update` track the **stable** channel by default — the latest non-prerelease GitHub release. To try release candidates ahead of a stable cut, opt into the **rc** channel:
+
+```bash
+maestro-relay-ctl channel rc      # persist the preference, then:
+maestro-relay-ctl update          # pulls the newest release, prereleases included
+maestro-relay-ctl update --rc     # …or switch + update in one step
+maestro-relay-ctl channel stable  # switch back (or: update --stable)
+```
+
+For a fresh install on the RC channel, set the env var:
+
+```bash
+MAESTRO_RELAY_CHANNEL=rc bash -c "$(curl -fsSL https://raw.githubusercontent.com/RunMaestro/Maestro-Relay/main/install.sh)"
+```
+
+RC builds are published as GitHub **prereleases** (tags like `v0.5.0-rc.1`), so the stable channel never picks them up. Pin an exact build with `MAESTRO_RELAY_VERSION=vX.Y.Z-rc.N`. The persisted channel lives at `~/.config/maestro-relay/channel`.
+
 ## Install (development from source)
 
 1. Clone and install:

--- a/bin/maestro-relay-ctl.sh
+++ b/bin/maestro-relay-ctl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Service wrapper for the Maestro Relay.
-# Subcommands: start | stop | restart | status | logs | deploy | update | uninstall | version
+# Subcommands: start | stop | restart | status | logs | deploy | update | channel | uninstall | version
 #
 # Backwards-compat: legacy MAESTRO_BRIDGE_* / MAESTRO_DISCORD_* env vars are accepted as fallback.
 # A legacy install at ~/.local/share/maestro-bridge or ~/.local/share/maestro-discord is auto-detected when
@@ -35,6 +35,8 @@ fi
 
 BIN_DIR="${MAESTRO_RELAY_BIN_DIR:-${MAESTRO_BRIDGE_BIN_DIR:-${MAESTRO_DISCORD_BIN_DIR:-$HOME/.local/bin}}}"
 REPO="${MAESTRO_RELAY_REPO:-${MAESTRO_BRIDGE_REPO:-${MAESTRO_DISCORD_REPO:-RunMaestro/Maestro-Relay}}}"
+# Persisted update-channel preference (stable|rc); see cmd_channel / cmd_update.
+CHANNEL_FILE="$CONFIG_DIR/channel"
 SERVICE_NAME="maestro-relay"
 LAUNCHD_LABEL="sh.maestro.relay"
 LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
@@ -45,6 +47,41 @@ LEGACY_LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LEGACY_LAUNCHD_LABEL}.plist"
 
 die() { printf '✗ %s\n' "$*" >&2; exit 1; }
 info() { printf '==> %s\n' "$*"; }
+
+validate_channel() {
+  case "$1" in
+    stable|rc) ;;
+    *) die "Invalid channel: $1 (expected 'stable' or 'rc')" ;;
+  esac
+}
+
+# Resolve the active update channel: explicit env override > persisted file >
+# 'stable' default. An unrecognized value (typo, stale file) is normalized to
+# 'stable' with a warning, so the reported channel and the actual behavior never
+# diverge. (resolve_channel runs inside $(...), where a die would only abort the
+# subshell — so it normalizes rather than exits; explicit sets still hard-fail
+# via persist_channel.)
+resolve_channel() {
+  local channel
+  if [ -n "${MAESTRO_RELAY_CHANNEL:-}" ]; then
+    channel="$MAESTRO_RELAY_CHANNEL"
+  elif [ -f "$CHANNEL_FILE" ]; then
+    channel="$(head -n1 "$CHANNEL_FILE" | tr -d '[:space:]')"
+  else
+    channel="stable"
+  fi
+  case "$channel" in
+    stable|rc) ;;
+    *) printf '⚠ Unknown update channel %q; using stable.\n' "$channel" >&2; channel="stable" ;;
+  esac
+  printf '%s' "$channel"
+}
+
+persist_channel() {
+  validate_channel "$1"
+  mkdir -p "$CONFIG_DIR"
+  printf '%s\n' "$1" > "$CHANNEL_FILE"
+}
 
 detect_os() {
   case "$(uname -s)" in
@@ -69,7 +106,8 @@ Commands:
   status      Show service status
   logs        Tail service logs (Ctrl+C to stop)
   deploy      Deploy chat commands for enabled providers (Discord slash commands, Telegram bot commands)
-  update      Reinstall the latest release (preserves config)
+  update      Reinstall the latest release (preserves config); pass --rc / --stable to pick the channel
+  channel     Show the update channel, or set it: 'channel rc' | 'channel stable'
   uninstall   Remove the relay, service files, and CLI symlinks
   version     Print installed version
 
@@ -77,6 +115,7 @@ Environment:
   MAESTRO_RELAY_HOME    Override install dir  (default: ~/.local/share/maestro-relay)
   XDG_CONFIG_HOME        Config dir parent     (default: ~/.config)
   MAESTRO_RELAY_MODULE   Installer-time module selection (currently: discord)
+  MAESTRO_RELAY_CHANNEL  Update channel: 'stable' (default) or 'rc' (release candidates)
   MAESTRO_BRIDGE_HOME    Accepted as fallback for back-compat
   MAESTRO_DISCORD_HOME   Accepted as fallback for back-compat with v0.0.x
 EOF
@@ -194,18 +233,58 @@ cmd_deploy() {
 }
 
 cmd_update() {
-  info "Re-running installer to pull the latest release"
-  local tag config_parent
-  tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n1)"
-  [ -n "$tag" ] || die "Could not resolve latest release tag"
+  local channel="" tag config_parent api
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --rc)     channel="rc" ;;
+      --stable) channel="stable" ;;
+      *) die "Unknown flag for update: $1 (expected --rc or --stable)" ;;
+    esac
+    shift
+  done
+  if [ -n "$channel" ]; then
+    persist_channel "$channel"
+  else
+    channel="$(resolve_channel)"
+  fi
+
+  if [ -n "${MAESTRO_RELAY_VERSION:-}" ]; then
+    # An explicit version pin wins over channel resolution, preserving the
+    # documented `MAESTRO_RELAY_VERSION=vX.Y.Z[-rc.N] … update` path.
+    tag="$MAESTRO_RELAY_VERSION"
+    info "Re-running installer to pull pinned ${tag}"
+  else
+    if [ "$channel" = "rc" ]; then
+      # Newest release including prereleases (the /releases list is newest-first).
+      api="https://api.github.com/repos/${REPO}/releases?per_page=20"
+    else
+      api="https://api.github.com/repos/${REPO}/releases/latest"
+    fi
+    tag="$(curl -fsSL "$api" | sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n1)"
+    [ -n "$tag" ] || die "Could not resolve a release tag on the '${channel}' channel"
+    info "Re-running installer to pull ${tag} (channel: ${channel})"
+  fi
+
   config_parent="$(dirname "$CONFIG_DIR")"
   curl -fsSL "https://raw.githubusercontent.com/${REPO}/${tag}/install.sh" \
     | env \
         MAESTRO_RELAY_HOME="$INSTALL_DIR" \
         MAESTRO_RELAY_BIN_DIR="$BIN_DIR" \
         MAESTRO_RELAY_REPO="$REPO" \
+        MAESTRO_RELAY_VERSION="$tag" \
+        MAESTRO_RELAY_CHANNEL="$channel" \
         XDG_CONFIG_HOME="$config_parent" \
         bash
+}
+
+cmd_channel() {
+  local arg="${1:-}"
+  if [ -z "$arg" ]; then
+    info "Update channel: $(resolve_channel)"
+    return
+  fi
+  persist_channel "$arg"
+  info "Update channel set to '$arg'. Run 'maestro-relay-ctl update' to apply."
 }
 
 cmd_uninstall() {
@@ -264,7 +343,8 @@ main() {
     status)    cmd_status ;;
     logs)      cmd_logs ;;
     deploy)    cmd_deploy ;;
-    update)    cmd_update ;;
+    update)    shift; cmd_update "$@" ;;
+    channel)   shift; cmd_channel "$@" ;;
     uninstall) cmd_uninstall ;;
     version)   cmd_version ;;
     -h|--help|help|"") usage ;;

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,10 @@ elif [ ! -d "$CONFIG_DIR" ] && [ -d "${XDG_CONFIG_HOME:-$HOME/.config}/maestro-d
 fi
 BIN_DIR="${MAESTRO_RELAY_BIN_DIR:-${MAESTRO_BRIDGE_BIN_DIR:-${MAESTRO_DISCORD_BIN_DIR:-$HOME/.local/bin}}}"
 VERSION="${MAESTRO_RELAY_VERSION:-${MAESTRO_BRIDGE_VERSION:-${MAESTRO_DISCORD_VERSION:-latest}}}"
+# Release channel: 'stable' (default) installs the latest non-prerelease GitHub
+# release; 'rc' installs the newest release *including* prereleases (release
+# candidates). Ignored when MAESTRO_RELAY_VERSION pins an explicit tag.
+CHANNEL="${MAESTRO_RELAY_CHANNEL:-stable}"
 MODULE="${MAESTRO_RELAY_MODULE:-${MAESTRO_BRIDGE_MODULE:-discord}}"
 NODE_MIN_MAJOR=22
 RELEASE_BACKUP=""
@@ -106,10 +110,17 @@ normalize_module() {
 
 resolve_release() {
   local api_url tag
-  if [ "$VERSION" = "latest" ]; then
-    api_url="https://api.github.com/repos/${REPO}/releases/latest"
-  else
+  if [ "$VERSION" != "latest" ]; then
+    # An explicit tag pin takes precedence over the channel.
     api_url="https://api.github.com/repos/${REPO}/releases/tags/${VERSION}"
+  elif [ "$CHANNEL" = "rc" ]; then
+    # RC channel: newest release *including* prereleases. The /releases list is
+    # returned newest-first, so the first tag_name is the most recently published
+    # release — a release-candidate or stable, whichever is newer.
+    api_url="https://api.github.com/repos/${REPO}/releases?per_page=20"
+  else
+    # Stable channel: GitHub's "latest" endpoint excludes prereleases.
+    api_url="https://api.github.com/repos/${REPO}/releases/latest"
   fi
   tag="$(curl -fsSL "$api_url" | sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n1)"
   [ -n "$tag" ] || die "Could not resolve release tag from ${api_url}"
@@ -862,6 +873,11 @@ main() {
   echo
   echo
 
+  case "$CHANNEL" in
+    stable|rc) ;;
+    *) die "Invalid MAESTRO_RELAY_CHANNEL: '$CHANNEL' (expected 'stable' or 'rc')" ;;
+  esac
+
   require_cmd curl
   require_cmd tar
   require_cmd sed
@@ -882,6 +898,10 @@ main() {
   install_ctl
   setup_voice
   write_config
+  # Record the active release channel so `maestro-relay-ctl update` keeps tracking
+  # it (stable or rc) without re-exporting MAESTRO_RELAY_CHANNEL on every update.
+  mkdir -p "$CONFIG_DIR"
+  printf '%s\n' "$CHANNEL" > "$CONFIG_DIR/channel"
   deploy_commands
   install_service
 


### PR DESCRIPTION
## Bring the channel-aware installer onto `rc`

Cherry-picks #54 (the opt-in RC release channel) from `main` onto `rc`, so the **rc branch — and therefore RC release tarballs cut from it — carry the channel-aware `install.sh` + `maestro-relay-ctl`**, not just the `release.yml` prerelease marking that rc already had.

### Why
`main` and `rc` had diverged: `main` got #54's channel installer, but `rc` only got the `release.yml` prerelease change (added when cutting `v0.5.0-rc.1`). That left a rough edge — the RC tarball's bundled `maestro-relay-ctl` lacked the `channel` / `update --rc` commands, and `$CONFIG_DIR/channel` written at install wasn't read back. This closes that gap so an RC install can stay on the rc channel across `update`.

### What's included (from #54, final squashed form)
- `install.sh`: `MAESTRO_RELAY_CHANNEL` (stable|rc), channel-aware `resolve_release`, validates the channel up front, persists it to `$CONFIG_DIR/channel` on install.
- `maestro-relay-ctl`: `update --rc/--stable`, `channel` subcommand, explicit `MAESTRO_RELAY_VERSION` pins preserved, unknown channels normalized to stable.
- README: channel docs.

The one conflict (the `deploy` usage line) was resolved to keep rc's multi-provider wording **and** the new `update`/`channel` lines. `release.yml` already had the identical prerelease line (deduped to one).

### Verification
- `bash -n` clean on both scripts; `channel` set/read smoke-tested
- `npm run build` clean; **316/316 tests pass**
- No conflict markers; `release.yml` has exactly one `prerelease:` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
