### PR TITLE
feat: GitHub-style callout embeds (Discord + Slack)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -73,6 +73,18 @@ Request: `Content-Type: application/json`
 
 `mention` is rendered by the provider in a platform-appropriate way (Discord prepends `<@DISCORD_MENTION_USER_ID>` to the first part of a multi-part message).
 
+#### Rich rendering
+
+The `message` body is rendered richly per provider — there is **no request-shape change**, detection is automatic:
+
+- **GitHub alert callouts** (`> [!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]` — uppercase, alone on their line) are auto-detected and rendered as a **colored Discord embed** / **colored Slack attachment**. A message containing multiple callouts **fans out into multiple provider messages**, each emitted in order with the surrounding prose. See [docs/discord.md → Callout embeds](discord.md#callout-embeds) and [docs/slack.md → Callout attachments](slack.md#callout-attachments).
+- **Markdown tables** in the body are rendered as aligned, fenced ASCII tables. **Behavior change:** the push path (`/api/send`) now applies this table rendering (`renderTables`) to text as it already did for agent replies — prior versions did not transform push text.
+
+Provider fallbacks:
+
+- **Teams** currently renders callouts as their raw `> [!TYPE]` blockquote via the text fallback (an Adaptive Card rendering is a future enhancement) — see [docs/teams.md → Runtime behavior](teams.md#runtime-behavior).
+- **Multi-agent rooms** do not yet render colored callouts (planned follow-up); callout text is delivered as-is.
+
 ### GET /api/health
 
 Returns bridge status:

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -87,6 +87,22 @@ npm run deploy-commands
 - **Usage stats** are appended below each agent reply (tokens, cost, context %).
 - **Markdown tables** in agent replies are rendered as aligned, fenced ASCII tables so they display correctly (Discord has no native table syntax). See [architecture.md → Output rendering](architecture.md#output-rendering).
 
+## Callout embeds
+
+Outbound text (agent replies and `/api/send` pushes) is scanned for **GitHub alert callouts** — a blockquote whose first line is `> [!NOTE]` (or `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`). The marker must be **uppercase** and **alone on its line** (GitHub-exact syntax); a plain `> quote` stays a normal grey Discord blockquote. Each detected callout is rendered as a **colored Discord embed emitted as its own message**, in order with the surrounding prose, so it visually stands apart from ordinary text.
+
+The five variants map to a matching emoji and accent color (the embed's left stripe):
+
+| Callout          | Emoji | Color     |
+| ---------------- | ----- | --------- |
+| `> [!NOTE]`      | ℹ️    | `#1f6feb` |
+| `> [!TIP]`       | 💡    | `#238636` |
+| `> [!IMPORTANT]` | ❗    | `#8957e5` |
+| `> [!WARNING]`   | ⚠️    | `#d29922` |
+| `> [!CAUTION]`   | 🛑    | `#da3633` |
+
+The callout body becomes the embed **description** and the emoji + label (e.g. `ℹ️ Note`) becomes the **title**. Discord's embed limits apply: descriptions are clamped to 4096 characters and titles to 256 — a longer body is truncated with a trailing ellipsis. Markdown tables inside a callout body are rendered the same way as elsewhere (fenced ASCII). Because each callout is its own message, a **callout-heavy response fans out into multiple messages**.
+
 ## Multi-agent rooms — real bot accounts
 
 A **room** hosts several agents in a single Discord channel, each speaking as a genuine, separate

--- a/docs/plans/callout-embeds.md
+++ b/docs/plans/callout-embeds.md
@@ -1,0 +1,418 @@
+# Plan: GitHub-style callout embeds for outbound messages
+
+**Status:** proposed (planning only — no implementation yet)
+**Author:** Maestro-Relay
+**Scope:** Discord + Slack (Teams = automatic text fallback, optional rich follow-up)
+
+---
+
+## 1. Goal
+
+Outbound agent/relay text often contains GitHub-flavored **alert callouts**:
+
+```markdown
+> [!CAUTION]
+> This will delete production data.
+```
+
+Today every outbound message is sent as a raw string, so Discord/Slack render this
+as a plain grey blockquote with the literal text `[!CAUTION]` — no color, no icon,
+no signal. We want each `> [!TYPE]` block to render as a **colored block** (Discord
+embed / Slack colored attachment), **interleaved in order** with the surrounding
+prose.
+
+Chris has explicitly accepted that **a callout may go out as its own message**
+(multiple messages per response is fine), which sidesteps the hard problem of
+mixing an embed *inside* one Discord message body.
+
+### Hard requirements (from the request)
+
+1. **Auto-detect, no opt-in.** Every `> [!TYPE]` block becomes a callout
+   automatically. No flag, **no change to `/api/send` callers**.
+2. **New splitter** (`src/core/callouts.ts`): Markdown → `Segment[]` where a
+   segment is `{ kind: 'text' | 'callout', variant?, title?, body }`. Robust to:
+   multi-line `>` blocks, code fences **inside** a callout, multiple callouts, a
+   callout at the very start/end, and **normal blockquotes** (`> ` with no
+   `[!TYPE]`) which must pass through untouched as text.
+3. **Sequential order.** Send segments one-by-one (`await` each) so Discord/Slack
+   preserve ordering. Text segments still flow through `splitMessage()`; callout
+   segments become an embed (Discord) / colored attachment (Slack).
+4. **Color/emoji map** (GitHub palette): see §4.
+5. **Slack:** one message per callout carrying **one** colored attachment
+   (`color`) — this fixes the "attachments pile up at the bottom" problem because
+   each callout message owns its attachment at the right point in the transcript.
+6. **Tests:** unit test for the splitter + adapter test (N segments → N sends,
+   embed/attachment fields correct, plain blockquotes stay text).
+7. **Risks/edge-cases** named: §8.
+
+---
+
+## 2. Current architecture (verified against source)
+
+There are **three** outbound paths that turn agent/relay text into provider
+`send()` calls. The color/callout logic must sit at a seam common to the ones we
+target.
+
+| Path | File / line | Transform applied today | Notes |
+|------|-------------|-------------------------|-------|
+| **Push** (`/api/send`) | `src/core/api.ts:133-176` | `split(body.message)` only — **no `renderTables`** | retry×3 + `RateLimitError` backoff per part |
+| **Agent reply** | `src/core/queue.ts:195-198` | `split(renderTables(result.response))` | simple `await` per part, no retry |
+| **Room persona** | `src/core/room/bus.ts:489-491` | `renderNativeMentions(renderTables(...))` → `split` → `sendAs` | out of scope for v1 |
+
+The **provider seam** is `provider.send(target, msg: OutgoingMessage)` (and
+`sendAs` for rooms). Every path ultimately loops `for (part of parts) send({text})`.
+
+Key existing building blocks we will reuse (do **not** reinvent):
+
+- `src/core/splitMessage.ts` — `splitMessage(text, max)` (fence-aware chunking).
+- `src/core/fences.ts` — `parseFenceLine`, `closesFence`, `Fence`. **This is how
+  `renderTables` stays fence-aware; the callout splitter must use the same primitives.**
+- `src/core/renderTables.ts` — `renderTables(text)` (already the model for a pure,
+  provider-free, fence-aware line scanner — mirror its structure).
+- `src/providers/discord/embed.ts` — `clampDescription` (`EMBED_DESCRIPTION_MAX =
+  4096`), `clampTitle` (`EMBED_TITLE_MAX = 256`).
+- `src/core/types.ts` — `OutgoingMessage` (currently `{ text; mention? }`).
+
+---
+
+## 3. Design
+
+### 3.1 Data model — extend `OutgoingMessage` (not a new provider method)
+
+Add an optional `callout` payload to `OutgoingMessage`. Rationale: a new
+`sendCallout()` method would force every provider to reimplement thread/channel
+resolution (Slack `thread_ts`, Discord thread-vs-channel, Teams conversation
+ref). Extending the existing message type keeps **one** send entry point per
+provider and gives **free graceful degradation**: a provider that ignores
+`msg.callout` still posts `msg.text`.
+
+```ts
+// src/core/types.ts
+export type CalloutVariant = 'NOTE' | 'TIP' | 'IMPORTANT' | 'WARNING' | 'CAUTION';
+
+export interface CalloutPayload {
+  variant: CalloutVariant;
+  /** Optional custom heading; when absent the provider derives "<emoji> <Label>". */
+  title?: string;
+  /** Callout body markdown (the `>`-stripped lines). May be empty. */
+  body: string;
+}
+
+export interface OutgoingMessage {
+  text: string;          // for a callout: the reconstructed raw blockquote (fallback)
+  mention?: boolean;
+  callout?: CalloutPayload;  // present → render rich; absent → plain text as today
+}
+```
+
+**Fallback contract:** when `toOutgoing` (§3.3) emits a callout message, it also
+sets `text` to the reconstructed `> [!TYPE]\n> body…` markdown. Any provider that
+does not special-case `.callout` (Teams today) posts that string — no worse than
+current behavior, and lossless.
+
+### 3.2 The splitter — `src/core/callouts.ts` (pure, provider-free)
+
+Mirror `renderTables`'s structure: a top-level, fence-aware line scanner.
+
+```ts
+export interface CalloutSegment {
+  kind: 'callout';
+  variant: CalloutVariant;
+  title?: string;   // reserved; not populated from GitHub syntax in v1 (see §8)
+  body: string;     // `>`-stripped body lines, joined by '\n'
+}
+export interface TextSegment { kind: 'text'; body: string; }
+export type Segment = TextSegment | CalloutSegment;
+
+export function splitCallouts(text: string): Segment[];
+```
+
+**Algorithm (line scan, fence-aware at the top level):**
+
+1. Split into lines. Track an open top-level fence with `parseFenceLine` /
+   `closesFence` (identical bookkeeping to `renderTables`). **While a top-level
+   fence is open, never start a callout** — this prevents a `> [!NOTE]` line that
+   lives *inside* a fenced code block from being mistaken for a callout.
+2. When not inside a fence and the current line is a **callout opener**, flush any
+   buffered text as a `TextSegment`, then consume the contiguous blockquote run.
+3. Otherwise append the line to the text buffer.
+4. Flush the final text buffer. Never emit empty text segments (a callout at the
+   very start/end therefore produces no stray empty segment).
+
+**Callout opener test:** after stripping ≤3 leading spaces, the line starts with
+`>`, and its content (after the `>` and one optional space) matches
+`^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*$` (uppercase, GitHub-exact — see
+§8 decision on case/trailing text).
+
+**Blockquote-run consumption:** from the opener, keep consuming while the line
+(after ≤3 spaces) starts with `>`. A bare `>` (empty body line) is part of the
+run; the run ends at the first non-`>` line or a truly blank line. Strip the
+`^ {0,3}> ?` prefix from each line. The **first** (marker) line is dropped from
+the body; the remainder is the `body`. A fenced block *inside* the quote (each
+line `>`-prefixed) is collected fine and, once `>`-stripped, becomes a real fence
+in the body → renders as code in the embed/attachment.
+
+**Plain blockquote pass-through:** `> just a quote` fails the opener test, so it
+stays in the text buffer and is emitted verbatim inside a `TextSegment`. ✅ Req #2.
+
+### 3.3 Composition helper — `toOutgoing`
+
+To keep the "mention only on the very first outbound message" rule correct across
+segments **and** avoid duplicating segmentation in both callers, add one composer
+in `src/core/callouts.ts` that returns the ordered list of `OutgoingMessage`s:
+
+```ts
+export function toOutgoing(
+  text: string,
+  opts: {
+    split: (t: string) => string[];        // injected splitMessage
+    renderTables: (t: string) => string;    // injected renderTables
+    mention?: boolean;
+  },
+): OutgoingMessage[];
+```
+
+Behavior:
+
+- `segments = splitCallouts(text)`.
+- For a `TextSegment`: `split(renderTables(body))` → one `OutgoingMessage`
+  `{ text: part }` per chunk.
+- For a `CalloutSegment`: **one** `OutgoingMessage` `{ text: rawBlockquote(seg),
+  callout: { variant, body } }`. (Optionally run `renderTables` on the callout
+  `body` too — see §8 decision.)
+- Set `mention: true` on **exactly the first** message in the returned array (when
+  `opts.mention`), so a multi-segment push pings once. All others `mention: false`.
+
+Unit-testable in isolation with stub `split`/`renderTables`.
+
+### 3.4 Shared callout metadata
+
+```ts
+// src/core/callouts.ts
+export const CALLOUT_META: Record<CalloutVariant, { label: string; emoji: string; hex: string }> = {
+  NOTE:      { label: 'Note',      emoji: 'ℹ️', hex: '#1f6feb' },
+  TIP:       { label: 'Tip',       emoji: '💡', hex: '#238636' },
+  IMPORTANT: { label: 'Important', emoji: '❗', hex: '#8957e5' },
+  WARNING:   { label: 'Warning',   emoji: '⚠️', hex: '#d29922' },
+  CAUTION:   { label: 'Caution',   emoji: '🛑', hex: '#da3633' },
+};
+```
+
+Provider-agnostic *data*; each provider converts to its own color unit.
+Default title = `` `${emoji} ${label}` ``.
+
+### 3.5 Caller changes
+
+**`src/core/api.ts` (push path).** Replace the `const parts = split(body.message)`
+loop. Refactor the existing retry/backoff body into a local `sendPart(msg:
+OutgoingMessage)` closure, then:
+
+```ts
+const messages = toOutgoing(body.message, { split, renderTables, mention: !!body.mention });
+for (const m of messages) { await sendPart(m); }   // retry/RateLimitError logic unchanged, per message
+```
+
+No change to `SendRequest` or any caller of `/api/send`. ✅ Req #1.
+(**Decision needed** — §8 #6 — whether to also start applying `renderTables` to
+push text; today the push path does not. Wrapping text segments in `renderTables`
+here would be a small, arguably-desirable behavior change.)
+
+**`src/core/queue.ts` (agent-reply path).** Replace lines 195-198:
+
+```ts
+for (const m of toOutgoing(result.response, { split, renderTables, mention: false })) {
+  await provider.send(target, m);
+}
+```
+
+This preserves the existing `renderTables` behavior for text and adds callouts.
+
+**Room path (`bus.ts`) is explicitly out of scope for v1** (personas + native
+mentions + `sendAs` interaction needs its own design). Note as follow-up.
+
+### 3.6 Provider rendering
+
+**Discord — `src/providers/discord/adapter.ts` `send()` (~line 277) and
+`postThrough()`.** When `msg.callout` is set, build an embed instead of a bare
+string:
+
+```ts
+const meta = CALLOUT_META[msg.callout.variant];
+const embed = {
+  title: clampTitle(msg.callout.title ?? `${meta.emoji} ${meta.label}`),
+  description: clampDescription(msg.callout.body),   // 4096 limit
+  color: parseInt(meta.hex.slice(1), 16),            // #1f6feb → 0x1f6feb
+};
+const content = (msg.mention && discordConfig.mentionUserId)
+  ? `<@${discordConfig.mentionUserId}>` : undefined;
+await channel.send({ content, embeds: [embed] });
+```
+
+- Empty `body` → embed with title only (valid; Discord requires title **or**
+  description). ✅
+- Mention rides in `content` so the ping still fires alongside the embed.
+- Same treatment in `postThrough()` for parity, but room `sendAs` is not yet a
+  caller of callouts, so this can be a thin addition or deferred.
+
+**Slack — `src/providers/slack/adapter.ts` `send()` (~line 317).** When
+`msg.callout` is set, post one message with one attachment, reusing the **same**
+channel/thread resolution already in `send()`:
+
+```ts
+const meta = CALLOUT_META[msg.callout.variant];
+const attachments = [{
+  color: meta.hex,                                   // hex string → colored left bar
+  title: msg.callout.title ?? `${meta.emoji} ${meta.label}`,
+  text: msg.callout.body,                            // mrkdwn
+}];
+const mentionText = (msg.mention && slackConfig.mentionUserId)
+  ? `<@${slackConfig.mentionUserId}>` : '';
+await this.client.chat.postMessage({ channel/thread_ts…, text: mentionText, attachments });
+```
+
+Each callout is its own message → its attachment sits at the correct point in the
+thread, solving the pile-up. ✅ Req #5.
+
+**Teams — no change required for v1.** `send()` reads `msg.text` and ignores
+unknown fields, so a callout automatically degrades to its raw-markdown blockquote
+(rendered with `textFormat: 'markdown'`). Optional follow-up: an Adaptive Card
+with a colored container. Note in `docs/teams.md`.
+
+---
+
+## 4. Color / emoji map (canonical)
+
+| Variant | Emoji | Hex | Discord int |
+|---------|-------|------|-------------|
+| NOTE | ℹ️ | `#1f6feb` | `2059499` |
+| TIP | 💡 | `#238636` | `2328118` |
+| IMPORTANT | ❗ | `#8957e5` | `8984549` |
+| WARNING | ⚠️ | `#d29922` | `13801762` |
+| CAUTION | 🛑 | `#da3633` | `14300723` |
+
+Embed/attachment **title** = `"<emoji> <Label>"`; **body** = the callout markdown
+via `clampDescription` (Discord) / `text` (Slack).
+
+---
+
+## 5. Files touched
+
+| File | Change |
+|------|--------|
+| `src/core/callouts.ts` | **new** — `splitCallouts`, `toOutgoing`, `CALLOUT_META`, types |
+| `src/core/types.ts` | add `CalloutVariant`, `CalloutPayload`, `OutgoingMessage.callout` |
+| `src/core/api.ts` | segment the push body via `toOutgoing`; wrap retry in `sendPart` |
+| `src/core/queue.ts` | replace reply send-loop with `toOutgoing` |
+| `src/providers/discord/adapter.ts` | render embed when `msg.callout` (in `send`, optionally `postThrough`) |
+| `src/providers/slack/adapter.ts` | render colored attachment when `msg.callout` |
+| `docs/discord.md`, `docs/slack.md`, `docs/api.md` | document callout rendering |
+| `.env.example` | no new vars (none needed) |
+
+No new dependencies.
+
+---
+
+## 6. Testing plan
+
+Follow existing patterns (`node --test`; `src/__tests__/embed.test.ts`,
+`split-mentions.test.ts`, `renderTables.test.ts`, `mockProvider.test.ts`).
+
+### 6.1 `src/__tests__/callouts.test.ts` (splitter unit tests)
+
+- Single callout → one `callout` segment, correct `variant`, `body` = stripped lines.
+- Prose → callout → prose ⇒ `[text, callout, text]` **in order**.
+- Callout at the very **start** and very **end** ⇒ no empty text segments.
+- **Multiple** callouts, different variants.
+- **Multi-line** body; bare `>` (empty) body line preserved.
+- **Fence inside** the callout — `>`-quoted ` ```bash ` block survives in `body`.
+- **Top-level fence containing `> [!NOTE]`** ⇒ stays text (NOT a callout). ← key robustness case.
+- **Plain blockquote** `> quote` (no `[!TYPE]`) ⇒ single text segment, verbatim.
+- Unknown tag `> [!FOOBAR]` ⇒ text (only the five variants match).
+- `toOutgoing`: mention set on first message only across mixed segments;
+  text segments run through injected `split`/`renderTables`; callout carries
+  reconstructed `text` fallback + `callout` payload.
+
+### 6.2 Adapter tests
+
+- **Discord** (`src/__tests__/discord-callout.test.ts`, mock `channel.send`):
+  input with 1 callout + 2 prose blocks ⇒ **N `send` calls in order**; the callout
+  call passes `{ embeds: [{ title, description, color }] }` with the right color
+  int and title; prose calls pass strings; a plain blockquote yields a string
+  (no embed). Assert 4096 clamp on an oversized body.
+- **Slack** (`src/__tests__/slack-callout.test.ts`, mock `chat.postMessage`):
+  callout ⇒ one `postMessage` with `attachments:[{ color:'#…', title, text }]`;
+  thread routing (`thread_ts`) preserved; N segments → N posts in order.
+- **Kernel-level** (extend `mockProvider.test.ts` style): a `MockProvider`
+  recording `msg.callout` confirms `toOutgoing` wiring end-to-end via the queue.
+
+---
+
+## 7. Rollout / sequencing
+
+1. `types.ts` + `callouts.ts` + `callouts.test.ts` (pure core, no provider risk).
+2. Wire `queue.ts` and `api.ts` through `toOutgoing` (text-only paths still pass —
+   callout messages just fall back to text until providers render them).
+3. Discord embed rendering + test.
+4. Slack attachment rendering + test.
+5. Docs.
+6. (Follow-up) room `bus.ts` + Teams Adaptive Card.
+
+Each step is independently green; providers degrade gracefully between steps.
+
+---
+
+## 8. Risks & edge cases
+
+1. **Rate limits from many segments.** N callouts ⇒ N messages ⇒ N API calls.
+   `api.ts` already retries with `RateLimitError` backoff per message, so the push
+   path is covered; `queue.ts` does not retry (unchanged risk — a burst of
+   callouts could 429). *Mitigation:* rely on existing api.ts backoff; consider a
+   small inter-segment delay only if observed. Document that callout-heavy output
+   fans out into multiple messages.
+2. **Discord embed description 4096 / title 256.** Long callout bodies are clamped
+   via `clampDescription`/`clampTitle` (lossy, ellipsized). *Decision:* accept
+   truncation for v1 (per request) rather than splitting one callout across
+   multiple embeds. Note it.
+3. **Empty / body-less callout** (`> [!NOTE]` alone). Discord: title-only embed
+   (valid). Slack: attachment with color + title, empty text (valid — colored bar).
+   Ensure we never send a Discord embed with neither title nor description.
+4. **Interaction with fence splitting.** The splitter is fence-aware at the top
+   level (reuses `fences.ts`) so a fenced block that *contains* `> [!TYPE]` is not
+   misread. Callout **bodies** are not re-run through `splitMessage` (a single
+   callout is one message); if a body exceeds 4096 it is clamped, not fence-split
+   — acceptable, but note that a very long fenced block inside a callout loses its
+   tail.
+5. **Interaction with `renderTables`.** A markdown table *inside* a callout body
+   would render as raw pipes in a Discord embed / Slack attachment unless we run
+   `renderTables` on the body. **Decision:** run `renderTables` on callout bodies
+   too (cheap, consistent with prose). Flag: embeds render the fenced ASCII table
+   fine; confirm Slack attachment `text` also renders the code fence (it does via
+   mrkdwn).
+6. **Push path `renderTables` gap.** `api.ts` currently does **not** apply
+   `renderTables` to pushed text. Routing push text through `toOutgoing` gives a
+   natural place to add it. **Decision needed:** (a) keep push text as-is (only
+   add callouts), or (b) also start rendering tables on pushes. Recommend (b) for
+   consistency, but it is a behavior change — call out in the PR.
+7. **Case sensitivity / trailing text on the marker.** GitHub matches uppercase
+   `[!NOTE]` alone on the line. **Decision:** match uppercase only; a marker with
+   trailing prose (`> [!NOTE] hi`) is treated as a plain blockquote (text) in v1.
+   Revisit if agents emit lowercase/titled variants — `title?` in the segment
+   type is reserved for that.
+8. **Mention placement.** Only the first outbound message carries the mention;
+   verify the ping still fires when the first message is a callout embed (Discord:
+   mention in `content`; Slack: mention in top-level `text` beside the attachment).
+9. **Room path unaddressed.** `bus.ts` still sends plain strings, so personas
+   won't get colored callouts in v1. Intentional; listed as follow-up.
+
+---
+
+## 9. Open decisions for Chris
+
+- **#6** — Should the push (`/api/send`) path also start applying `renderTables`
+  (currently it doesn't), or keep it callouts-only? (Recommend: apply it.)
+- **#5** — Run `renderTables` on callout **bodies**? (Recommend: yes.)
+- **#7** — Uppercase-only, marker-alone matching (GitHub-exact)? (Recommend: yes.)
+- **Room scope** — confirm rooms (`bus.ts`) are a follow-up, not v1.
+- **Teams** — text fallback for v1, Adaptive Card later? (Recommend: yes.)
+</content>
+</invoke>

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -70,7 +70,24 @@ The Slack provider deliberately ships a smaller command surface than Discord —
 - **Typing indicator**: not exposed by Slack's Web API; `sendTyping` is a no-op on this provider.
 - **Usage stats** are appended below each agent reply (tokens, cost, context %).
 - **Markdown tables** in agent replies are rendered as aligned, fenced ASCII tables so they display correctly (Slack mrkdwn has no native table syntax). See [architecture.md → Output rendering](architecture.md#output-rendering).
+- **Callout attachments**: outbound text containing GitHub alert callouts renders as colored Slack attachments — see [Callout attachments](#callout-attachments) below.
 - **Channel naming**: agent channels are named `maestro-<sanitized-agent-name>-<id-prefix>`, where `id-prefix` is the first 8 alphanumeric characters of the agent ID. The agent ID makes the name unique even when two different agents normalize to the same display name. The whole result is capped at 80 characters. Both `/agents new` and the HTTP-API auto-create path (`POST /api/send`) use the same helper. If the channel already exists but is archived, the adapter unarchives it; if unarchive fails, it falls back to creating a fresh channel with a `-<timestamp>` suffix appended to the base name.
+
+## Callout attachments
+
+Outbound text (agent replies and `/api/send` pushes) is scanned for **GitHub alert callouts** — a blockquote whose first line is `> [!NOTE]` (or `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`). The marker must be **uppercase** and **alone on its line** (GitHub-exact syntax); a plain `> quote` stays an ordinary Slack blockquote. Each detected callout is posted as a **Slack message carrying one colored attachment** — the attachment's `color` paints the vertical bar down its left edge — emitted in order with the surrounding prose so each callout sits at the right point in the thread.
+
+The five variants map to a matching emoji and accent color (the attachment's left bar):
+
+| Callout          | Emoji | Color     |
+| ---------------- | ----- | --------- |
+| `> [!NOTE]`      | ℹ️    | `#1f6feb` |
+| `> [!TIP]`       | 💡    | `#238636` |
+| `> [!IMPORTANT]` | ❗    | `#8957e5` |
+| `> [!WARNING]`   | ⚠️    | `#d29922` |
+| `> [!CAUTION]`   | 🛑    | `#da3633` |
+
+The emoji + label (e.g. `ℹ️ Note`) becomes the attachment's **title** and the callout body its `text` (mrkdwn, so a fenced table inside the body renders correctly). **Thread routing is preserved** — a callout in a threaded reply posts to the same parent channel with the thread's `thread_ts`, exactly like ordinary segments. Because each callout is its own message, a **callout-heavy response fans out into multiple messages**.
 
 ## Storage
 

--- a/docs/teams.md
+++ b/docs/teams.md
@@ -164,6 +164,7 @@ A message that is not a recognized command flows through to the bound agent. If 
 - **Proactive `/api/send` requires a prior chat** — the HTTP API's `POST /api/send` and the `maestro-relay` CLI can only push to a Teams chat **after** that chat has been bound and a reference captured. Sending to a chat the bot has never seen fails with "No conversation reference found". If you need proactive delivery, **message the bot first**.
 - **No reactions** — Teams bots cannot add emoji reactions, so the `⏳` queued indicator used by Discord/Slack is **absent**. Instead the adapter sends a **typing indicator** while a turn is in flight (best-effort; a failure never breaks the turn).
 - **Markdown tables** in agent replies are rendered as aligned, fenced ASCII tables (Teams' markdown has no native table syntax). See [architecture.md → Output rendering](architecture.md#output-rendering).
+- **Callouts render as plain blockquotes** — GitHub alert callouts (`> [!NOTE]` etc.) that Discord and Slack render as colored embeds/attachments degrade on Teams to their reconstructed `> [!TYPE]` blockquote via the message's text fallback. A richer Adaptive Card rendering is a future enhancement.
 - **Usage stats** (tokens, cost, context %) are appended below each agent reply.
 - **Message splitting** — long replies are split by the kernel to fit Teams' per-message size limit before they are sent.
 - **Mentions** — when an API caller passes `mention=true` and `TEAMS_MENTION_USER_ID` is set, the reply is prefixed with an `<at>…</at>` tag.

--- a/src/__tests__/callouts.test.ts
+++ b/src/__tests__/callouts.test.ts
@@ -1,0 +1,281 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  splitCallouts,
+  toOutgoing,
+  CALLOUT_META,
+  type Segment,
+  type CalloutSegment,
+  type TextSegment,
+} from '../core/callouts';
+
+/**
+ * Covers plan §6.1 for the pure callout splitter/composer. `splitCallouts` is a
+ * fence-aware line scanner; `toOutgoing` composes segments into OutgoingMessage[]
+ * using injected `split`/`renderTables` helpers (kept provider-free).
+ */
+
+/** Narrowing helper: assert a segment is a callout and return it. */
+function asCallout(seg: Segment): CalloutSegment {
+  assert.equal(seg.kind, 'callout', `expected a callout segment, got ${seg.kind}`);
+  return seg as CalloutSegment;
+}
+
+/** Narrowing helper: assert a segment is text and return it. */
+function asText(seg: Segment): TextSegment {
+  assert.equal(seg.kind, 'text', `expected a text segment, got ${seg.kind}`);
+  return seg as TextSegment;
+}
+
+// ---------------------------------------------------------------------------
+// splitCallouts
+// ---------------------------------------------------------------------------
+
+test('splitCallouts: a single callout yields one callout segment with stripped body', () => {
+  const input = ['> [!NOTE]', '> Remember to hydrate.'].join('\n');
+  const segs = splitCallouts(input);
+
+  assert.equal(segs.length, 1);
+  const c = asCallout(segs[0]);
+  assert.equal(c.variant, 'NOTE');
+  assert.equal(c.body, 'Remember to hydrate.', 'body is `>`-stripped, marker dropped');
+});
+
+test('splitCallouts: prose → callout → prose gives [text, callout, text] in order', () => {
+  const input = [
+    'Before the callout.',
+    '> [!TIP]',
+    '> Use a linter.',
+    'After the callout.',
+  ].join('\n');
+  const segs = splitCallouts(input);
+
+  assert.equal(segs.length, 3);
+  assert.deepEqual(
+    segs.map((s) => s.kind),
+    ['text', 'callout', 'text'],
+  );
+  assert.equal(asText(segs[0]).body, 'Before the callout.');
+  assert.equal(asCallout(segs[1]).variant, 'TIP');
+  assert.equal(asCallout(segs[1]).body, 'Use a linter.');
+  assert.equal(asText(segs[2]).body, 'After the callout.');
+});
+
+test('splitCallouts: callout at the very start AND very end emits no empty text segments', () => {
+  const input = [
+    '> [!NOTE]',
+    '> First.',
+    'middle prose',
+    '> [!WARNING]',
+    '> Last.',
+  ].join('\n');
+  const segs = splitCallouts(input);
+
+  assert.deepEqual(
+    segs.map((s) => s.kind),
+    ['callout', 'text', 'callout'],
+  );
+  // No segment is an empty text segment.
+  assert.ok(!segs.some((s) => s.kind === 'text' && s.body === ''), 'no empty text segments');
+});
+
+test('splitCallouts: multiple callouts of different variants each parse', () => {
+  // GitHub (and the run-consumption rule) treats a blockquote as continuous:
+  // distinct callouts must be separated by a blank line, else they are one run.
+  const input = [
+    '> [!NOTE]',
+    '> n',
+    '',
+    '> [!TIP]',
+    '> t',
+    '',
+    '> [!IMPORTANT]',
+    '> i',
+    '',
+    '> [!CAUTION]',
+    '> c',
+  ].join('\n');
+  const segs = splitCallouts(input);
+
+  assert.deepEqual(
+    segs.map((s) => (s.kind === 'callout' ? s.variant : s.kind)),
+    ['NOTE', 'TIP', 'IMPORTANT', 'CAUTION'],
+  );
+});
+
+test('splitCallouts: multi-line body preserves a bare `>` empty line', () => {
+  const input = ['> [!NOTE]', '> line one', '>', '> line three'].join('\n');
+  const segs = splitCallouts(input);
+
+  assert.equal(segs.length, 1);
+  const c = asCallout(segs[0]);
+  assert.equal(c.body, 'line one\n\nline three', 'bare `>` becomes an empty body line');
+});
+
+test('splitCallouts: a `>`-quoted fenced block inside the callout survives in the body', () => {
+  const input = [
+    '> [!TIP]',
+    '> Run:',
+    '> ```bash',
+    '> echo hi',
+    '> ```',
+  ].join('\n');
+  const segs = splitCallouts(input);
+
+  assert.equal(segs.length, 1);
+  const c = asCallout(segs[0]);
+  assert.equal(c.variant, 'TIP');
+  assert.equal(c.body, ['Run:', '```bash', 'echo hi', '```'].join('\n'));
+});
+
+test('splitCallouts: a top-level fenced block containing a `> [!NOTE]` line stays ONE text segment', () => {
+  const input = [
+    '```md',
+    'Example of a callout:',
+    '> [!NOTE]',
+    '> not a real callout here',
+    '```',
+  ].join('\n');
+  const segs = splitCallouts(input);
+
+  assert.equal(segs.length, 1, 'the whole fenced block is a single text segment');
+  const t = asText(segs[0]);
+  assert.equal(t.body, input, 'fenced content is preserved verbatim, no callout extracted');
+});
+
+test('splitCallouts: a plain blockquote with no [!TYPE] stays a single verbatim text segment', () => {
+  const input = ['> just a quote', '> second line'].join('\n');
+  const segs = splitCallouts(input);
+
+  assert.equal(segs.length, 1);
+  assert.equal(asText(segs[0]).body, input);
+});
+
+test('splitCallouts: an unknown tag `> [!FOOBAR]` is treated as text', () => {
+  const input = ['> [!FOOBAR]', '> body'].join('\n');
+  const segs = splitCallouts(input);
+
+  assert.equal(segs.length, 1);
+  assert.equal(asText(segs[0]).body, input);
+});
+
+test('splitCallouts: a marker with trailing prose `> [!NOTE] hi` is NOT an opener', () => {
+  const input = ['> [!NOTE] hi', '> more'].join('\n');
+  const segs = splitCallouts(input);
+
+  assert.equal(segs.length, 1);
+  assert.equal(asText(segs[0]).body, input, 'GitHub-exact: trailing prose disqualifies the marker');
+});
+
+test('splitCallouts: lowercase `> [!note]` is NOT an opener (uppercase-only)', () => {
+  const input = ['> [!note]', '> body'].join('\n');
+  const segs = splitCallouts(input);
+
+  assert.equal(segs.length, 1);
+  assert.equal(asText(segs[0]).kind, 'text');
+});
+
+// ---------------------------------------------------------------------------
+// CALLOUT_META
+// ---------------------------------------------------------------------------
+
+test('CALLOUT_META has an entry for every variant with label/emoji/hex', () => {
+  for (const variant of ['NOTE', 'TIP', 'IMPORTANT', 'WARNING', 'CAUTION'] as const) {
+    const meta = CALLOUT_META[variant];
+    assert.ok(meta, `${variant} present`);
+    assert.equal(typeof meta.label, 'string');
+    assert.equal(typeof meta.emoji, 'string');
+    assert.match(meta.hex, /^#[0-9a-f]{6}$/, `${variant} hex is a 6-digit color`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// toOutgoing
+// ---------------------------------------------------------------------------
+
+const identitySplit = (t: string) => [t];
+const identityTables = (t: string) => t;
+
+test('toOutgoing: text segments pass through the injected split and renderTables', () => {
+  const calls: { split: string[]; tables: string[] } = { split: [], tables: [] };
+  const split = (t: string) => {
+    calls.split.push(t);
+    return [t];
+  };
+  const renderTables = (t: string) => {
+    calls.tables.push(t);
+    return `[T]${t}`;
+  };
+
+  const msgs = toOutgoing('plain prose', { split, renderTables });
+
+  assert.equal(msgs.length, 1);
+  assert.equal(msgs[0].text, '[T]plain prose', 'renderTables applied then split');
+  assert.deepEqual(calls.tables, ['plain prose']);
+  assert.deepEqual(calls.split, ['[T]plain prose']);
+});
+
+test('toOutgoing: a text segment that splits into N chunks yields N messages', () => {
+  const split = (t: string) => t.split('|');
+  const msgs = toOutgoing('a|b|c', { split, renderTables: identityTables });
+
+  assert.deepEqual(
+    msgs.map((m) => m.text),
+    ['a', 'b', 'c'],
+  );
+  assert.ok(msgs.every((m) => m.callout === undefined), 'text messages carry no callout');
+});
+
+test('toOutgoing: a callout message carries both the blockquote fallback text AND the callout payload', () => {
+  const input = ['> [!WARNING]', '> Danger ahead.'].join('\n');
+  const msgs = toOutgoing(input, { split: identitySplit, renderTables: identityTables });
+
+  assert.equal(msgs.length, 1);
+  const m = msgs[0];
+  assert.equal(m.text, ['> [!WARNING]', '> Danger ahead.'].join('\n'), 'lossless blockquote fallback');
+  assert.ok(m.callout, 'callout payload present');
+  assert.equal(m.callout!.variant, 'WARNING');
+  assert.equal(m.callout!.body, 'Danger ahead.');
+});
+
+test('toOutgoing: renderTables is applied to the callout body too (decision #5)', () => {
+  const input = ['> [!NOTE]', '> body text'].join('\n');
+  const renderTables = (t: string) => `<rt>${t}</rt>`;
+  const msgs = toOutgoing(input, { split: identitySplit, renderTables });
+
+  assert.equal(msgs[0].callout!.body, '<rt>body text</rt>', 'callout body passed through renderTables');
+});
+
+test('toOutgoing: mention is set on the FIRST message only across mixed segments', () => {
+  const input = [
+    'intro',
+    '> [!TIP]',
+    '> a tip',
+    'outro',
+  ].join('\n');
+  // Split the leading text into two chunks so the first message is a text chunk.
+  const split = (t: string) => (t === 'intro' ? ['intro-1', 'intro-2'] : [t]);
+  const msgs = toOutgoing(input, { split, renderTables: identityTables, mention: true });
+
+  assert.ok(msgs.length >= 3, 'multiple messages produced');
+  assert.equal(msgs[0].mention, true, 'first message is mentioned');
+  assert.ok(
+    msgs.slice(1).every((m) => m.mention !== true),
+    'no later message is mentioned',
+  );
+});
+
+test('toOutgoing: without opts.mention no message is mentioned', () => {
+  const msgs = toOutgoing('hello', { split: identitySplit, renderTables: identityTables });
+  assert.ok(msgs.every((m) => m.mention !== true));
+});
+
+test('toOutgoing: a callout with an empty body reconstructs a lone marker fallback', () => {
+  const input = '> [!IMPORTANT]';
+  const msgs = toOutgoing(input, { split: identitySplit, renderTables: identityTables });
+
+  assert.equal(msgs.length, 1);
+  assert.equal(msgs[0].text, '> [!IMPORTANT]', 'empty body → just the marker line');
+  assert.equal(msgs[0].callout!.variant, 'IMPORTANT');
+  assert.equal(msgs[0].callout!.body, '');
+});

--- a/src/__tests__/discord-callout.test.ts
+++ b/src/__tests__/discord-callout.test.ts
@@ -6,6 +6,7 @@ import { CALLOUT_META } from '../core/callouts';
 import { splitMessage } from '../core/splitMessage';
 import { renderTables } from '../core/renderTables';
 import { EMBED_DESCRIPTION_MAX } from '../providers/discord/embed';
+import { RateLimitError } from '../core/errors';
 import type { ChannelTarget, OutgoingMessage } from '../core/types';
 
 /**
@@ -145,4 +146,85 @@ test('an oversized callout body is clamped to the 4096 description limit', async
   const { embeds } = asEmbedCall(calls[0]);
   const description = embeds[0].data.description as string;
   assert.ok(description.length <= EMBED_DESCRIPTION_MAX, 'description clamped via clampDescription');
+});
+
+test('a failing embed send degrades to the plaintext blockquote fallback', async () => {
+  const calls: unknown[] = [];
+  // Reject only the embed send; the plaintext retry succeeds.
+  const channel = {
+    isSendable() {
+      return true;
+    },
+    async send(arg: unknown) {
+      calls.push(arg);
+      if (typeof arg === 'object' && arg !== null && 'embeds' in arg) {
+        throw new Error('Missing Permissions');
+      }
+      return {};
+    },
+  };
+  const provider = makeProvider(channel);
+
+  const msg: OutgoingMessage = {
+    text: '> [!NOTE]\n> hello world',
+    callout: { variant: 'NOTE', body: 'hello world' },
+  };
+  await provider.send(TARGET, msg);
+
+  assert.equal(calls.length, 2, 'embed attempted, then the plaintext fallback');
+  assert.equal(calls[1], msg.text, 'fallback posts the lossless blockquote string');
+});
+
+test('a rate-limited embed send propagates instead of degrading', async () => {
+  const calls: unknown[] = [];
+  const channel = {
+    isSendable() {
+      return true;
+    },
+    async send(arg: unknown) {
+      calls.push(arg);
+      throw Object.assign(new Error('rate limited'), { status: 429, retryAfter: 250 });
+    },
+  };
+  const provider = makeProvider(channel);
+
+  await assert.rejects(
+    provider.send(TARGET, { text: '> [!NOTE]\n> hi', callout: { variant: 'NOTE', body: 'hi' } }),
+    (err: unknown) => err instanceof RateLimitError,
+    'rate limits surface to sendWithRetry rather than degrading',
+  );
+  assert.equal(calls.length, 1, 'no plaintext fallback attempted on a rate limit');
+});
+
+test('a callout fallback carries the mention prefix', async () => {
+  const prev = process.env.DISCORD_MENTION_USER_ID;
+  process.env.DISCORD_MENTION_USER_ID = 'U-ping';
+  try {
+    const calls: unknown[] = [];
+    const channel = {
+      isSendable() {
+        return true;
+      },
+      async send(arg: unknown) {
+        calls.push(arg);
+        if (typeof arg === 'object' && arg !== null && 'embeds' in arg) {
+          throw new Error('Missing Permissions');
+        }
+        return {};
+      },
+    };
+    const provider = makeProvider(channel);
+
+    await provider.send(TARGET, {
+      text: '> [!NOTE]\n> hi',
+      callout: { variant: 'NOTE', body: 'hi' },
+      mention: true,
+    });
+
+    assert.equal(calls.length, 2);
+    assert.match(calls[1] as string, /^<@U-ping> /, 'fallback keeps the ping');
+  } finally {
+    if (prev === undefined) delete process.env.DISCORD_MENTION_USER_ID;
+    else process.env.DISCORD_MENTION_USER_ID = prev;
+  }
 });

--- a/src/__tests__/discord-callout.test.ts
+++ b/src/__tests__/discord-callout.test.ts
@@ -1,0 +1,148 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DiscordProvider } from '../providers/discord/adapter';
+import { toOutgoing } from '../core/callouts';
+import { CALLOUT_META } from '../core/callouts';
+import { splitMessage } from '../core/splitMessage';
+import { renderTables } from '../core/renderTables';
+import { EMBED_DESCRIPTION_MAX } from '../providers/discord/embed';
+import type { ChannelTarget, OutgoingMessage } from '../core/types';
+
+/**
+ * Discord callout embed rendering (Phase 03). The adapter's `send()` must turn a
+ * message carrying `msg.callout` into a colored `EmbedBuilder` (title = emoji +
+ * label, description = body, color = the variant hex as an int) while leaving
+ * ordinary prose messages as plain strings. We drive the public `send()` against
+ * a mocked sendable channel, injecting a fake client so no gateway is needed.
+ */
+
+/** A stand-in sendable channel that records every `send()` argument in order. */
+function makeChannel(): { channel: unknown; calls: unknown[] } {
+  const calls: unknown[] = [];
+  const channel = {
+    isSendable() {
+      return true;
+    },
+    async send(arg: unknown) {
+      calls.push(arg);
+      return {};
+    },
+  };
+  return { channel, calls };
+}
+
+/** A `DiscordProvider` whose private client resolves every fetch to `channel`. */
+function makeProvider(channel: unknown): DiscordProvider {
+  const provider = new DiscordProvider();
+  (provider as unknown as { client: unknown }).client = {
+    channels: {
+      async fetch() {
+        return channel;
+      },
+    },
+  };
+  return provider;
+}
+
+const TARGET: ChannelTarget = { provider: 'discord', channelId: 'C-test' };
+
+/** Narrow a recorded call to the discord.js embed-send object shape. */
+function asEmbedCall(arg: unknown): { content?: unknown; embeds: { data: Record<string, unknown> }[] } {
+  assert.equal(typeof arg, 'object', 'callout call passes an options object, not a string');
+  const obj = arg as { embeds?: { data: Record<string, unknown> }[] };
+  assert.ok(Array.isArray(obj.embeds), 'callout call includes an embeds array');
+  return obj as { content?: unknown; embeds: { data: Record<string, unknown> }[] };
+}
+
+test('1 callout + 2 prose blocks ⇒ 3 send calls in order (prose=string, callout=embed)', async () => {
+  const { channel, calls } = makeChannel();
+  const provider = makeProvider(channel);
+
+  const text = 'para one\n\n> [!NOTE]\n> hello world\n\npara two';
+  const messages = toOutgoing(text, { split: splitMessage, renderTables });
+  assert.equal(messages.length, 3, 'toOutgoing yields text, callout, text');
+
+  for (const m of messages) await provider.send(TARGET, m);
+
+  assert.equal(calls.length, 3, 'one send() per message, in order');
+
+  // First and last are prose → plain strings, no embeds.
+  assert.equal(typeof calls[0], 'string');
+  assert.equal(typeof calls[2], 'string');
+  assert.match(calls[0] as string, /para one/);
+  assert.match(calls[2] as string, /para two/);
+
+  // Middle is the callout → embed with the NOTE presentation.
+  const meta = CALLOUT_META.NOTE;
+  const { embeds } = asEmbedCall(calls[1]);
+  assert.equal(embeds.length, 1);
+  assert.equal(embeds[0].data.title, `${meta.emoji} ${meta.label}`);
+  assert.equal(embeds[0].data.description, 'hello world');
+  assert.equal(embeds[0].data.color, parseInt(meta.hex.slice(1), 16));
+  // Independent anchor: NOTE's #1f6feb as a Discord color int.
+  assert.equal(embeds[0].data.color, 2060267);
+});
+
+test('a plain blockquote (> quote) renders as a string, not an embed', async () => {
+  const { channel, calls } = makeChannel();
+  const provider = makeProvider(channel);
+
+  const messages = toOutgoing('> just a quote', { split: splitMessage, renderTables });
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].callout, undefined, 'a plain blockquote is not a callout');
+
+  for (const m of messages) await provider.send(TARGET, m);
+
+  assert.equal(calls.length, 1);
+  assert.equal(typeof calls[0], 'string');
+  assert.match(calls[0] as string, /just a quote/);
+});
+
+test('each callout variant embeds its own label, emoji, and color', async () => {
+  for (const variant of Object.keys(CALLOUT_META) as (keyof typeof CALLOUT_META)[]) {
+    const { channel, calls } = makeChannel();
+    const provider = makeProvider(channel);
+    const meta = CALLOUT_META[variant];
+
+    const msg: OutgoingMessage = {
+      text: `> [!${variant}]\n> body`,
+      callout: { variant, body: 'body text' },
+    };
+    await provider.send(TARGET, msg);
+
+    const { embeds } = asEmbedCall(calls[0]);
+    assert.equal(embeds[0].data.title, `${meta.emoji} ${meta.label}`, `${variant} title`);
+    assert.equal(embeds[0].data.description, 'body text', `${variant} description`);
+    assert.equal(embeds[0].data.color, parseInt(meta.hex.slice(1), 16), `${variant} color`);
+  }
+});
+
+test('an empty callout body yields a title-only embed (no description)', async () => {
+  const { channel, calls } = makeChannel();
+  const provider = makeProvider(channel);
+
+  const msg: OutgoingMessage = {
+    text: '> [!TIP]',
+    callout: { variant: 'TIP', body: '' },
+  };
+  await provider.send(TARGET, msg);
+
+  const { embeds } = asEmbedCall(calls[0]);
+  assert.equal(embeds[0].data.title, `${CALLOUT_META.TIP.emoji} ${CALLOUT_META.TIP.label}`);
+  assert.equal(embeds[0].data.description, undefined, 'empty body leaves description unset');
+});
+
+test('an oversized callout body is clamped to the 4096 description limit', async () => {
+  const { channel, calls } = makeChannel();
+  const provider = makeProvider(channel);
+
+  const msg: OutgoingMessage = {
+    text: '> [!WARNING]\n> big',
+    callout: { variant: 'WARNING', body: 'x'.repeat(EMBED_DESCRIPTION_MAX + 500) },
+  };
+  await provider.send(TARGET, msg);
+
+  const { embeds } = asEmbedCall(calls[0]);
+  const description = embeds[0].data.description as string;
+  assert.ok(description.length <= EMBED_DESCRIPTION_MAX, 'description clamped via clampDescription');
+});

--- a/src/__tests__/sendRetry.test.ts
+++ b/src/__tests__/sendRetry.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sendWithRetry } from '../core/sendRetry';
+import { RateLimitError } from '../core/errors';
+import type { OutgoingMessage } from '../core/types';
+
+const MSG: OutgoingMessage = { text: 'hello' };
+
+test('sendWithRetry calls send exactly once when it succeeds first try', async () => {
+  let calls = 0;
+  await sendWithRetry(async () => {
+    calls++;
+  }, MSG);
+  assert.equal(calls, 1);
+});
+
+test('sendWithRetry retries after RateLimitError then resolves, invoking onRateLimit per backoff', async () => {
+  let calls = 0;
+  const waits: number[] = [];
+  await sendWithRetry(
+    async () => {
+      calls++;
+      if (calls <= 2) throw new RateLimitError(5);
+    },
+    MSG,
+    { onRateLimit: (ms) => waits.push(ms) },
+  );
+  assert.equal(calls, 3);
+  // Two rate-limited attempts → two backoffs, each clamped up to the 100ms floor.
+  assert.deepEqual(waits, [100, 100]);
+});
+
+test('sendWithRetry rejects with a RateLimitError after exhausting attempts', async () => {
+  let calls = 0;
+  await assert.rejects(
+    sendWithRetry(
+      async () => {
+        calls++;
+        throw new RateLimitError(5);
+      },
+      MSG,
+      { retries: 2 },
+    ),
+    (err: unknown) => err instanceof RateLimitError,
+  );
+  assert.equal(calls, 2);
+});
+
+test('sendWithRetry rethrows a non-RateLimitError immediately without retrying', async () => {
+  let calls = 0;
+  await assert.rejects(
+    sendWithRetry(async () => {
+      calls++;
+      throw new Error('boom');
+    }, MSG),
+    (err: unknown) => err instanceof Error && err.message === 'boom',
+  );
+  assert.equal(calls, 1);
+});

--- a/src/__tests__/slack-callout.test.ts
+++ b/src/__tests__/slack-callout.test.ts
@@ -40,9 +40,11 @@ function makeProvider(client: unknown): SlackProvider {
 const CHANNEL_TARGET: ChannelTarget = { provider: 'slack', channelId: 'C-test' };
 
 /** Narrow a recorded call's `attachments` to the shape we assert against. */
-function attachmentsOf(arg: Record<string, unknown>): { color: string; title: string; text: string }[] {
+function attachmentsOf(
+  arg: Record<string, unknown>,
+): { color: string; title: string; text: string; mrkdwn_in?: string[] }[] {
   assert.ok(Array.isArray(arg.attachments), 'callout post includes an attachments array');
-  return arg.attachments as { color: string; title: string; text: string }[];
+  return arg.attachments as { color: string; title: string; text: string; mrkdwn_in?: string[] }[];
 }
 
 test('a callout ⇒ one postMessage with a single colored attachment', async () => {
@@ -63,6 +65,10 @@ test('a callout ⇒ one postMessage with a single colored attachment', async () 
   assert.equal(attachments[0].color, '#1f6feb', 'NOTE hex anchor');
   assert.equal(attachments[0].title, `${meta.emoji} ${meta.label}`);
   assert.equal(attachments[0].text, 'hello world');
+  assert.ok(
+    Array.isArray(attachments[0].mrkdwn_in) && attachments[0].mrkdwn_in.includes('text'),
+    'attachment sets mrkdwn_in including "text" so body markdown renders',
+  );
   assert.equal(calls[0].channel, 'C-test', 'posts to the plain channel target');
 });
 

--- a/src/__tests__/slack-callout.test.ts
+++ b/src/__tests__/slack-callout.test.ts
@@ -5,6 +5,12 @@ import { conversationDb } from '../providers/slack/conversationsDb';
 import { toOutgoing, CALLOUT_META } from '../core/callouts';
 import { splitMessage } from '../core/splitMessage';
 import { renderTables } from '../core/renderTables';
+import { RateLimitError } from '../core/errors';
+import {
+  ATTACHMENT_TEXT_MAX,
+  ATTACHMENT_TITLE_MAX,
+  MESSAGE_TEXT_MAX,
+} from '../providers/slack/attachment';
 import type { ChannelTarget, OutgoingMessage } from '../core/types';
 
 /**
@@ -154,6 +160,138 @@ test('N mixed segments ⇒ N postMessage calls in order (prose=text, callout=att
   assert.equal(attachments[0].color, meta.hex);
   assert.equal(attachments[0].title, `${meta.emoji} ${meta.label}`);
   assert.equal(attachments[0].text, 'hello world');
+});
+
+test('an over-length callout body is clamped to the attachment text limit', async () => {
+  const { client, calls } = makeClient();
+  const provider = makeProvider(client);
+
+  const huge = 'a'.repeat(ATTACHMENT_TEXT_MAX + 5000);
+  await provider.send(CHANNEL_TARGET, {
+    text: `> [!NOTE]\n> ${huge}`,
+    callout: { variant: 'NOTE', body: huge },
+  });
+
+  const attachments = attachmentsOf(calls[0]);
+  assert.ok(
+    attachments[0].text.length <= ATTACHMENT_TEXT_MAX,
+    `body clamped to ${ATTACHMENT_TEXT_MAX} (got ${attachments[0].text.length})`,
+  );
+  assert.ok(attachments[0].text.endsWith('…'), 'clamped body is marked with an ellipsis');
+});
+
+test('an over-length callout title is clamped to the attachment title limit', async () => {
+  const { client, calls } = makeClient();
+  const provider = makeProvider(client);
+
+  const huge = 'T'.repeat(ATTACHMENT_TITLE_MAX + 500);
+  await provider.send(CHANNEL_TARGET, {
+    text: '> [!TIP]\n> body',
+    callout: { variant: 'TIP', title: huge, body: 'body' },
+  });
+
+  const attachments = attachmentsOf(calls[0]);
+  assert.ok(
+    attachments[0].title.length <= ATTACHMENT_TITLE_MAX,
+    `title clamped to ${ATTACHMENT_TITLE_MAX} (got ${attachments[0].title.length})`,
+  );
+  assert.ok(attachments[0].title.endsWith('…'), 'clamped title is marked with an ellipsis');
+});
+
+test('an over-length plain message text is clamped to the message limit', async () => {
+  const { client, calls } = makeClient();
+  const provider = makeProvider(client);
+
+  await provider.send(CHANNEL_TARGET, { text: 'x'.repeat(MESSAGE_TEXT_MAX + 5000) });
+
+  const text = calls[0].text as string;
+  assert.ok(text.length <= MESSAGE_TEXT_MAX, `text clamped to ${MESSAGE_TEXT_MAX}`);
+  assert.ok(text.endsWith('…'), 'clamped text is marked with an ellipsis');
+});
+
+test('bodies at exactly the limit are left untouched', async () => {
+  const { client, calls } = makeClient();
+  const provider = makeProvider(client);
+
+  const exact = 'b'.repeat(ATTACHMENT_TEXT_MAX);
+  await provider.send(CHANNEL_TARGET, {
+    text: '> [!NOTE]\n> body',
+    callout: { variant: 'NOTE', body: exact },
+  });
+
+  const attachments = attachmentsOf(calls[0]);
+  assert.equal(attachments[0].text, exact, 'a body exactly at the limit is not clamped');
+});
+
+test('a failing attachment post degrades to the plaintext blockquote fallback', async () => {
+  const calls: Record<string, unknown>[] = [];
+  // Reject only the rich post; the plaintext retry succeeds.
+  const client = {
+    chat: {
+      async postMessage(arg: Record<string, unknown>) {
+        calls.push(arg);
+        if (arg.attachments) throw new Error('invalid_attachments');
+        return { ok: true };
+      },
+    },
+  };
+  const provider = makeProvider(client);
+
+  const msg: OutgoingMessage = {
+    text: '> [!NOTE]\n> hello world',
+    callout: { variant: 'NOTE', body: 'hello world' },
+  };
+  await provider.send(CHANNEL_TARGET, msg);
+
+  assert.equal(calls.length, 2, 'rich post attempted, then the plaintext fallback');
+  assert.ok(calls[0].attachments, 'first attempt carried the attachment');
+  assert.equal(calls[1].attachments, undefined, 'fallback is a plain text post');
+  assert.equal(calls[1].text, msg.text, 'fallback posts the lossless blockquote');
+});
+
+test('a rate-limited callout post propagates instead of degrading', async () => {
+  const calls: Record<string, unknown>[] = [];
+  const client = {
+    chat: {
+      async postMessage(arg: Record<string, unknown>) {
+        calls.push(arg);
+        throw Object.assign(new Error('ratelimited'), {
+          code: 'slack_webapi_rate_limited_error',
+          retryAfter: 3,
+        });
+      },
+    },
+  };
+  const provider = makeProvider(client);
+
+  await assert.rejects(
+    provider.send(CHANNEL_TARGET, {
+      text: '> [!NOTE]\n> hi',
+      callout: { variant: 'NOTE', body: 'hi' },
+    }),
+    (err: unknown) => err instanceof RateLimitError,
+    'rate limits surface to sendWithRetry rather than degrading',
+  );
+  assert.equal(calls.length, 1, 'no plaintext fallback attempted on a rate limit');
+});
+
+test('a fallback that also fails surfaces the fallback error', async () => {
+  const client = {
+    chat: {
+      async postMessage() {
+        throw new Error('channel_not_found');
+      },
+    },
+  };
+  const provider = makeProvider(client);
+
+  await assert.rejects(
+    provider.send(CHANNEL_TARGET, {
+      text: '> [!NOTE]\n> hi',
+      callout: { variant: 'NOTE', body: 'hi' },
+    }),
+    /channel_not_found/,
+  );
 });
 
 test('a mention rides in the top-level text beside the attachment', async () => {

--- a/src/__tests__/slack-callout.test.ts
+++ b/src/__tests__/slack-callout.test.ts
@@ -1,0 +1,176 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SlackProvider } from '../providers/slack/adapter';
+import { conversationDb } from '../providers/slack/conversationsDb';
+import { toOutgoing, CALLOUT_META } from '../core/callouts';
+import { splitMessage } from '../core/splitMessage';
+import { renderTables } from '../core/renderTables';
+import type { ChannelTarget, OutgoingMessage } from '../core/types';
+
+/**
+ * Slack callout attachment rendering (Phase 04). The adapter's `send()` must
+ * turn a message carrying `msg.callout` into a single colored attachment (title
+ * = emoji + label, text = body, color = the variant hex) while leaving ordinary
+ * prose messages as plain `text` posts. The channel-vs-thread resolution is
+ * shared by both branches. We drive the public `send()` against a mocked
+ * `chat.postMessage`, injecting a fake client so no Slack app is needed.
+ */
+
+/** A stand-in Slack client that records every `chat.postMessage` payload in order. */
+function makeClient(): { client: unknown; calls: Record<string, unknown>[] } {
+  const calls: Record<string, unknown>[] = [];
+  const client = {
+    chat: {
+      async postMessage(arg: Record<string, unknown>) {
+        calls.push(arg);
+        return { ok: true };
+      },
+    },
+  };
+  return { client, calls };
+}
+
+/** A `SlackProvider` whose private client is the injected mock. */
+function makeProvider(client: unknown): SlackProvider {
+  const provider = new SlackProvider();
+  (provider as unknown as { client: unknown }).client = client;
+  return provider;
+}
+
+const CHANNEL_TARGET: ChannelTarget = { provider: 'slack', channelId: 'C-test' };
+
+/** Narrow a recorded call's `attachments` to the shape we assert against. */
+function attachmentsOf(arg: Record<string, unknown>): { color: string; title: string; text: string }[] {
+  assert.ok(Array.isArray(arg.attachments), 'callout post includes an attachments array');
+  return arg.attachments as { color: string; title: string; text: string }[];
+}
+
+test('a callout ⇒ one postMessage with a single colored attachment', async () => {
+  const { client, calls } = makeClient();
+  const provider = makeProvider(client);
+
+  const msg: OutgoingMessage = {
+    text: '> [!NOTE]\n> hello world',
+    callout: { variant: 'NOTE', body: 'hello world' },
+  };
+  await provider.send(CHANNEL_TARGET, msg);
+
+  assert.equal(calls.length, 1, 'exactly one postMessage call');
+  const meta = CALLOUT_META.NOTE;
+  const attachments = attachmentsOf(calls[0]);
+  assert.equal(attachments.length, 1, 'a single attachment per callout');
+  assert.equal(attachments[0].color, meta.hex);
+  assert.equal(attachments[0].color, '#1f6feb', 'NOTE hex anchor');
+  assert.equal(attachments[0].title, `${meta.emoji} ${meta.label}`);
+  assert.equal(attachments[0].text, 'hello world');
+  assert.equal(calls[0].channel, 'C-test', 'posts to the plain channel target');
+});
+
+test('each callout variant attaches its own label, emoji, and color', async () => {
+  for (const variant of Object.keys(CALLOUT_META) as (keyof typeof CALLOUT_META)[]) {
+    const { client, calls } = makeClient();
+    const provider = makeProvider(client);
+    const meta = CALLOUT_META[variant];
+
+    const msg: OutgoingMessage = {
+      text: `> [!${variant}]\n> body`,
+      callout: { variant, body: 'body text' },
+    };
+    await provider.send(CHANNEL_TARGET, msg);
+
+    const attachments = attachmentsOf(calls[0]);
+    assert.equal(attachments[0].color, meta.hex, `${variant} color`);
+    assert.equal(attachments[0].title, `${meta.emoji} ${meta.label}`, `${variant} title`);
+    assert.equal(attachments[0].text, 'body text', `${variant} text`);
+  }
+});
+
+test('a custom callout title overrides the emoji+label default', async () => {
+  const { client, calls } = makeClient();
+  const provider = makeProvider(client);
+
+  const msg: OutgoingMessage = {
+    text: '> [!TIP]\n> body',
+    callout: { variant: 'TIP', title: 'Custom Heading', body: 'body' },
+  };
+  await provider.send(CHANNEL_TARGET, msg);
+
+  const attachments = attachmentsOf(calls[0]);
+  assert.equal(attachments[0].title, 'Custom Heading');
+});
+
+test('thread targets resolve to parent channel + thread_ts, attachment preserved', async () => {
+  const threadTs = '1777189034.828869';
+  conversationDb.register(threadTs, 'C-parent', 'agent-1', 'U-owner');
+  try {
+    const { client, calls } = makeClient();
+    const provider = makeProvider(client);
+
+    const msg: OutgoingMessage = {
+      text: '> [!WARNING]\n> heads up',
+      callout: { variant: 'WARNING', body: 'heads up' },
+    };
+    await provider.send({ provider: 'slack', channelId: threadTs }, msg);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].channel, 'C-parent', 'resolves the parent channel');
+    assert.equal(calls[0].thread_ts, threadTs, 'keeps the thread_ts');
+    const attachments = attachmentsOf(calls[0]);
+    assert.equal(attachments[0].color, CALLOUT_META.WARNING.hex);
+    assert.equal(attachments[0].text, 'heads up');
+  } finally {
+    conversationDb.remove(threadTs);
+  }
+});
+
+test('N mixed segments ⇒ N postMessage calls in order (prose=text, callout=attachment)', async () => {
+  const { client, calls } = makeClient();
+  const provider = makeProvider(client);
+
+  const text = 'para one\n\n> [!NOTE]\n> hello world\n\npara two';
+  const messages = toOutgoing(text, { split: splitMessage, renderTables });
+  assert.equal(messages.length, 3, 'toOutgoing yields text, callout, text');
+
+  for (const m of messages) await provider.send(CHANNEL_TARGET, m);
+
+  assert.equal(calls.length, 3, 'one postMessage per message, in order');
+
+  // First and last are prose → plain text, no attachments.
+  assert.equal(calls[0].attachments, undefined, 'prose post has no attachments');
+  assert.equal(calls[2].attachments, undefined, 'prose post has no attachments');
+  assert.match(calls[0].text as string, /para one/);
+  assert.match(calls[2].text as string, /para two/);
+
+  // Middle is the callout → attachment with the NOTE presentation.
+  const meta = CALLOUT_META.NOTE;
+  const attachments = attachmentsOf(calls[1]);
+  assert.equal(attachments.length, 1);
+  assert.equal(attachments[0].color, meta.hex);
+  assert.equal(attachments[0].title, `${meta.emoji} ${meta.label}`);
+  assert.equal(attachments[0].text, 'hello world');
+});
+
+test('a mention rides in the top-level text beside the attachment', async () => {
+  const prev = process.env.SLACK_MENTION_USER_ID;
+  process.env.SLACK_MENTION_USER_ID = 'U-ping';
+  try {
+    const { client, calls } = makeClient();
+    const provider = makeProvider(client);
+
+    const msg: OutgoingMessage = {
+      text: '> [!IMPORTANT]\n> read me',
+      callout: { variant: 'IMPORTANT', body: 'read me' },
+      mention: true,
+    };
+    await provider.send(CHANNEL_TARGET, msg);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].text, '<@U-ping>', 'mention is in the top-level text');
+    const attachments = attachmentsOf(calls[0]);
+    assert.equal(attachments.length, 1, 'attachment still present alongside the mention');
+    assert.equal(attachments[0].text, 'read me');
+  } finally {
+    if (prev === undefined) delete process.env.SLACK_MENTION_USER_ID;
+    else process.env.SLACK_MENTION_USER_ID = prev;
+  }
+});

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -4,6 +4,9 @@ import { config } from './config';
 import { logger } from './logger';
 import { splitMessage as defaultSplit } from './splitMessage';
 import { AgentNotFoundError, RateLimitError } from './errors';
+import { toOutgoing } from './callouts';
+import { renderTables } from './renderTables';
+import { sendWithRetry } from './sendRetry';
 
 export interface SendRequest {
   agentId: string;
@@ -130,49 +133,35 @@ export function createServerHandler(deps: ApiDeps) {
     }
 
     const target = { provider: providerName, channelId: info.channelId };
-    const parts = split(body.message);
+    // Table-render + length-split text and surface GitHub-style callouts as their
+    // own messages. `toOutgoing` applies `mention` to only the first message, so
+    // the old per-part `i === 0` mention logic is no longer needed. Applying
+    // `renderTables` to pushed text is an intentional behavior change (decision #6).
+    const messages = toOutgoing(body.message, { split, renderTables, mention: !!body.mention });
 
-    for (let i = 0; i < parts.length; i++) {
-      const part = parts[i];
-      let lastError: Error | undefined;
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          // Mention only on the first part; provider decides how to render.
-          await provider.send(target, { text: part, mention: i === 0 && !!body.mention });
-          lastError = undefined;
-          break;
-        } catch (err) {
-          lastError = err as Error;
-          if (err instanceof RateLimitError) {
-            // Clamp the in-request backoff: never spin with a zero delay, and
-            // never tie up the HTTP connection for more than a few seconds.
-            // Larger backoffs are surfaced to the caller via Retry-After below.
-            const waitMs = Math.min(Math.max(err.retryAfterMs, 100), 5000);
-            await new Promise((r) => setTimeout(r, waitMs));
-          } else {
-            break;
-          }
-        }
+    try {
+      for (const m of messages) {
+        await sendWithRetry((x) => provider.send(target, x), m);
       }
-      if (lastError) {
-        if (lastError instanceof RateLimitError) {
-          await log.error('api', 'Rate limited by provider after 3 retries');
-          // Round up to whole seconds; clamp to a minimum of 1 so we never
-          // advertise a zero-second backoff that the kernel already waited
-          // through and still hit the limit.
-          const retryAfterSec = Math.max(1, Math.ceil(lastError.retryAfterMs / 1000));
-          sendJson(
-            res,
-            429,
-            { success: false, error: 'Rate limited, retry later' },
-            { 'Retry-After': retryAfterSec },
-          );
-        } else {
-          await log.error('api', lastError.message);
-          sendJson(res, 500, { success: false, error: lastError.message });
-        }
-        return;
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        await log.error('api', 'Rate limited by provider after 3 retries');
+        // Round up to whole seconds; clamp to a minimum of 1 so we never
+        // advertise a zero-second backoff that the kernel already waited
+        // through and still hit the limit.
+        const retryAfterSec = Math.max(1, Math.ceil(err.retryAfterMs / 1000));
+        sendJson(
+          res,
+          429,
+          { success: false, error: 'Rate limited, retry later' },
+          { 'Retry-After': retryAfterSec },
+        );
+      } else {
+        const msg = (err as Error).message;
+        await log.error('api', msg);
+        sendJson(res, 500, { success: false, error: msg });
       }
+      return;
     }
 
     sendJson(res, 200, { success: true, channelId: info.channelId });

--- a/src/core/callouts.ts
+++ b/src/core/callouts.ts
@@ -1,0 +1,190 @@
+/**
+ * Provider-agnostic GitHub-style callout (a.k.a. "alert") detection and message
+ * composition.
+ *
+ * GitHub renders a blockquote whose first line is `> [!NOTE]` (or `[!TIP]`,
+ * `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`) as a colored, icon-labeled
+ * callout. Chat platforms don't, so we detect these blocks in outbound agent
+ * text and hand providers a structured `CalloutPayload` they can render richly
+ * (Discord embed, Slack attachment). The surrounding prose is split normally.
+ *
+ * Like `renderTables`, this module is pure and provider-free by design (see
+ * CLAUDE.md): nothing here imports a chat SDK. Fence bookkeeping is shared with
+ * `renderTables`/`splitMessage` via `./fences` so a callout marker that appears
+ * inside a fenced code block is never mistaken for a real callout.
+ */
+
+import { parseFenceLine, closesFence, type Fence } from './fences';
+import type { CalloutVariant, CalloutPayload, OutgoingMessage } from './types';
+
+/** A run of ordinary (non-callout) markdown. */
+export interface TextSegment {
+  kind: 'text';
+  body: string;
+}
+
+/** A detected callout block. `title` is reserved (never set in v1). */
+export interface CalloutSegment {
+  kind: 'callout';
+  variant: CalloutVariant;
+  title?: string;
+  /** The `>`-stripped callout body markdown, marker line dropped (may be empty). */
+  body: string;
+}
+
+export type Segment = TextSegment | CalloutSegment;
+
+/**
+ * Per-variant presentation metadata (plan §3.4). `hex` is a GitHub-matched
+ * accent color providers can use for an embed/attachment stripe; `emoji` and
+ * `label` prefix the rendered title.
+ */
+export const CALLOUT_META: Record<CalloutVariant, { label: string; emoji: string; hex: string }> = {
+  NOTE: { label: 'Note', emoji: 'ℹ️', hex: '#1f6feb' },
+  TIP: { label: 'Tip', emoji: '💡', hex: '#238636' },
+  IMPORTANT: { label: 'Important', emoji: '❗', hex: '#8957e5' },
+  WARNING: { label: 'Warning', emoji: '⚠️', hex: '#d29922' },
+  CAUTION: { label: 'Caution', emoji: '🛑', hex: '#da3633' },
+};
+
+/**
+ * A callout opener: `> [!VARIANT]` alone on the line (uppercase-only, GitHub
+ * exact). Up to three leading spaces and one optional space after `>` are
+ * allowed; any trailing prose (`> [!NOTE] hi`) disqualifies it.
+ */
+const OPENER_RE = /^ {0,3}> ?\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*$/;
+
+function matchOpener(line: string): CalloutVariant | null {
+  const m = line.match(OPENER_RE);
+  return m ? (m[1] as CalloutVariant) : null;
+}
+
+/** Whether a line is part of a blockquote run (a bare `>` counts). */
+function isBlockquoteLine(line: string): boolean {
+  return /^ {0,3}>/.test(line);
+}
+
+/** Strip the `^ {0,3}> ?` blockquote prefix from a line. */
+function stripQuote(line: string): string {
+  return line.replace(/^ {0,3}> ?/, '');
+}
+
+/**
+ * Split `text` into ordered text/callout segments. Fence-aware: while a
+ * top-level code fence is open a callout is never started, so a `> [!NOTE]`
+ * line that lives inside a fenced block stays part of the surrounding text.
+ * Empty text segments are never emitted.
+ */
+export function splitCallouts(text: string): Segment[] {
+  const lines = text.split('\n');
+  const segments: Segment[] = [];
+  let buf: string[] = [];
+  let open: Fence | null = null; // current open top-level code fence, or null
+
+  const flushText = () => {
+    if (buf.length > 0) {
+      const body = buf.join('\n');
+      // Never emit an empty text segment: a blank-only buffer (e.g. the blank
+      // line separating two adjacent callouts) carries no content and is dropped.
+      if (body.trim().length > 0) {
+        segments.push({ kind: 'text', body });
+      }
+      buf = [];
+    }
+  };
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+
+    const fence = parseFenceLine(line);
+    if (fence) {
+      if (open) {
+        if (closesFence(open, fence)) open = null;
+      } else {
+        open = fence;
+      }
+      buf.push(line);
+      i++;
+      continue;
+    }
+
+    if (open === null) {
+      const variant = matchOpener(line);
+      if (variant) {
+        flushText();
+        // Consume the contiguous blockquote run starting at the opener; it ends
+        // at the first non-`>` line. A `>`-quoted fenced block survives here as
+        // real markdown once the quote prefix is stripped.
+        const bodyLines: string[] = [];
+        let j = i;
+        while (j < lines.length && isBlockquoteLine(lines[j])) {
+          bodyLines.push(stripQuote(lines[j]));
+          j++;
+        }
+        bodyLines.shift(); // drop the marker line
+        segments.push({ kind: 'callout', variant, body: bodyLines.join('\n') });
+        i = j;
+        continue;
+      }
+    }
+
+    buf.push(line);
+    i++;
+  }
+
+  flushText();
+  return segments;
+}
+
+/**
+ * Reconstruct a lossless `> [!VARIANT]` blockquote from a callout segment so a
+ * provider that ignores `.callout` still posts a faithful fallback.
+ */
+function rawBlockquote(seg: CalloutSegment): string {
+  const out = [`> [!${seg.variant}]`];
+  if (seg.body.length > 0) {
+    for (const line of seg.body.split('\n')) out.push(`> ${line}`);
+  }
+  return out.join('\n');
+}
+
+/**
+ * Turn raw agent text into an ordered `OutgoingMessage[]` (plan §3.3).
+ *
+ * Text segments are table-rendered then length-split via the injected helpers,
+ * one message per chunk. Each callout becomes exactly one message carrying both
+ * a reconstructed blockquote `text` fallback and a rich `callout` payload (whose
+ * body is also table-rendered). `mention` is applied to only the first message.
+ */
+export function toOutgoing(
+  text: string,
+  opts: {
+    split: (t: string) => string[];
+    renderTables: (t: string) => string;
+    mention?: boolean;
+  },
+): OutgoingMessage[] {
+  const segments = splitCallouts(text);
+  const messages: OutgoingMessage[] = [];
+
+  for (const seg of segments) {
+    if (seg.kind === 'text') {
+      for (const part of opts.split(opts.renderTables(seg.body))) {
+        messages.push({ text: part });
+      }
+    } else {
+      const callout: CalloutPayload = {
+        variant: seg.variant,
+        body: opts.renderTables(seg.body),
+      };
+      messages.push({ text: rawBlockquote(seg), callout });
+    }
+  }
+
+  if (opts.mention && messages.length > 0) {
+    messages[0].mention = true;
+  }
+
+  return messages;
+}

--- a/src/core/clampText.ts
+++ b/src/core/clampText.ts
@@ -1,0 +1,19 @@
+/**
+ * Length clamping for provider payload fields.
+ *
+ * Every chat platform caps the fields of a rich message (Discord embed titles,
+ * Slack attachment text, ...) and rejects or silently truncates anything longer.
+ * The clamp itself is identical everywhere — cut to the limit, mark that a cut
+ * happened — so it lives here in the pure core while each provider keeps its own
+ * limit constants next to the code that knows them (`discord/embed.ts`,
+ * `slack/attachment.ts`).
+ */
+
+const ELLIPSIS = '\n…';
+
+/** Truncate `text` to `max` chars, appending an ellipsis marker if truncated. */
+export function clampText(text: string, max: number): string {
+  if (text.length <= max) return text;
+  if (max <= ELLIPSIS.length) return text.slice(0, max);
+  return text.slice(0, max - ELLIPSIS.length) + ELLIPSIS;
+}

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -8,6 +8,8 @@ import type {
 } from './types';
 import { splitMessage as defaultSplitMessage } from './splitMessage';
 import { renderTables } from './renderTables';
+import { toOutgoing } from './callouts';
+import { sendWithRetry } from './sendRetry';
 import { downloadAttachments as defaultDownload, formatAttachmentRefs } from './attachments';
 
 interface QueueEntry {
@@ -192,9 +194,8 @@ export function createQueue(deps: QueueDeps) {
             `agent=${conv.agentId} session=${conv.sessionId ?? 'new'} channel=${message.channelId} error=${result.error}`,
           );
         }
-        const parts = split(renderTables(result.response));
-        for (const part of parts) {
-          await provider.send(target, { text: part });
+        for (const m of toOutgoing(result.response, { split, renderTables, mention: false })) {
+          await sendWithRetry((x) => provider.send(target, x), m);
         }
       } else {
         const hint = conv.readOnly

--- a/src/core/sendRetry.ts
+++ b/src/core/sendRetry.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared send-with-retry helper.
+ *
+ * Extracts the per-message retry/backoff that both outbound paths need — the
+ * push API (`api.ts`) and the agent reply path (`queue.ts`). Callouts multiply
+ * the number of messages emitted per response, so a burst can hit a provider's
+ * rate limit; centralizing the backoff keeps the two paths in lockstep instead
+ * of duplicating (and drifting) the logic.
+ *
+ * Pure core: no provider-SDK imports. Callers pass a `send` closure that hides
+ * the provider/target details.
+ */
+
+import { RateLimitError } from './errors';
+import type { OutgoingMessage } from './types';
+
+export interface SendWithRetryOptions {
+  /** Total attempts before giving up (default 3). */
+  retries?: number;
+  /** Invoked with the clamped backoff (ms) each time a rate limit is hit. */
+  onRateLimit?: (waitMs: number) => void;
+}
+
+/**
+ * Attempt `send(msg)` up to `retries` times (default 3).
+ *
+ * On a caught `RateLimitError` it waits `clamp(err.retryAfterMs, 100, 5000)` ms
+ * then retries; the clamp never spins on a zero delay and never ties up the
+ * caller for more than a few seconds. On any non-`RateLimitError` it rethrows
+ * immediately. If every attempt is exhausted it rethrows the last error, so a
+ * caller can translate a final `RateLimitError` into an HTTP 429.
+ */
+export async function sendWithRetry(
+  send: (msg: OutgoingMessage) => Promise<void>,
+  msg: OutgoingMessage,
+  opts: SendWithRetryOptions = {},
+): Promise<void> {
+  const retries = opts.retries ?? 3;
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      await send(msg);
+      return;
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        lastError = err;
+        const waitMs = Math.min(Math.max(err.retryAfterMs, 100), 5000);
+        opts.onRateLimit?.(waitMs);
+        await new Promise((r) => setTimeout(r, waitMs));
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  // Exhausted all attempts on rate limits; surface the last one so callers can
+  // translate it (e.g. HTTP 429 with a Retry-After header).
+  throw lastError;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -58,6 +58,29 @@ export interface IncomingMessage {
   raw?: unknown;
 }
 
+/**
+ * The five canonical GitHub-style alert callout variants
+ * (`> [!NOTE]` / `[!TIP]` / `[!IMPORTANT]` / `[!WARNING]` / `[!CAUTION]`).
+ * Uppercase-only; no other tags are recognized.
+ */
+export type CalloutVariant = 'NOTE' | 'TIP' | 'IMPORTANT' | 'WARNING' | 'CAUTION';
+
+/**
+ * A parsed callout, provider-agnostic. Providers that understand callouts render
+ * this richly (Discord embed, Slack attachment); providers that don't fall back
+ * to the message's plain `text`.
+ */
+export interface CalloutPayload {
+  variant: CalloutVariant;
+  /**
+   * Reserved for a future custom-title syntax; NOT populated from GitHub
+   * callout syntax in v1 (GitHub callouts have no inline title).
+   */
+  title?: string;
+  /** The `>`-stripped callout markdown body (may be empty). */
+  body: string;
+}
+
 export interface OutgoingMessage {
   text: string;
   /**
@@ -66,6 +89,12 @@ export interface OutgoingMessage {
    * Slack would use SLACK_MENTION_USER_ID, etc.).
    */
   mention?: boolean;
+  /**
+   * When present, the provider renders this callout richly (colored embed /
+   * attachment). When a provider ignores it, the message degrades gracefully to
+   * `text`, which carries a lossless blockquote fallback.
+   */
+  callout?: CalloutPayload;
 }
 
 /**

--- a/src/providers/discord/adapter.ts
+++ b/src/providers/discord/adapter.ts
@@ -4,6 +4,7 @@ import {
   ChannelType,
   ChatInputCommandInteraction,
   Client,
+  EmbedBuilder,
   GatewayIntentBits,
   Interaction,
   SendableChannels,
@@ -25,6 +26,8 @@ import { maestro } from '../../core/maestro';
 import { logger } from '../../core/logger';
 import { checkTranscriptionDependencies } from '../../core/transcription';
 import { AgentNotFoundError, RateLimitError } from '../../core/errors';
+import { CALLOUT_META } from '../../core/callouts';
+import { clampTitle, clampDescription } from './embed';
 import { discordConfig } from './config';
 import { channelDb } from './channelsDb';
 import { threadDb } from './threadsDb';
@@ -276,6 +279,34 @@ export class DiscordProvider implements BridgeProvider {
 
   async send(target: ChannelTarget, msg: OutgoingMessage): Promise<void> {
     const channel = await this.fetchSendable(target.channelId);
+
+    // Callout messages render as a colored embed; the human mention (when any)
+    // rides in `content` so the ping fires alongside the embed. Plain messages
+    // keep the original mention-prefixed string behavior below.
+    if (msg.callout) {
+      const meta = CALLOUT_META[msg.callout.variant];
+      const embed = new EmbedBuilder()
+        .setTitle(clampTitle(msg.callout.title ?? `${meta.emoji} ${meta.label}`))
+        .setColor(parseInt(meta.hex.slice(1), 16));
+      // Discord requires a title OR description; only set description when the
+      // body is non-empty, leaving a valid title-only embed otherwise.
+      if (msg.callout.body.length > 0) {
+        embed.setDescription(clampDescription(msg.callout.body));
+      }
+      const content =
+        msg.mention && discordConfig.mentionUserId
+          ? `<@${discordConfig.mentionUserId}>`
+          : undefined;
+      try {
+        await channel.send({ content, embeds: [embed] });
+      } catch (err) {
+        const rl = toRateLimitError(err);
+        if (rl) throw rl;
+        throw err;
+      }
+      return;
+    }
+
     let text = msg.text;
     if (msg.mention && discordConfig.mentionUserId) {
       text = `<@${discordConfig.mentionUserId}> ${text}`;
@@ -360,6 +391,10 @@ export class DiscordProvider implements BridgeProvider {
     maskName?: string,
   ): Promise<void> {
     const channel = await this.fetchSendableFrom(client, target.threadId ?? target.channelId);
+    // NOTE: room `sendAs` callout rendering (colored embeds per persona) is a
+    // follow-up — rooms are out of scope for v1, so this path posts `msg.text`
+    // only and ignores `msg.callout`. `send()` posts directly (it does not share
+    // this helper), so its callout-embed construction is not factored here.
     let text = msg.text;
     if (maskName) {
       text = `**${maskName}:** ${text}`;

--- a/src/providers/discord/adapter.ts
+++ b/src/providers/discord/adapter.ts
@@ -302,7 +302,23 @@ export class DiscordProvider implements BridgeProvider {
       } catch (err) {
         const rl = toRateLimitError(err);
         if (rl) throw rl;
-        throw err;
+        // The embed can fail on grounds plain text won't hit (a rejected field,
+        // missing Embed Links in this channel). `msg.text` holds a lossless
+        // `> [!VARIANT]` blockquote of the same content (see core/callouts.ts
+        // `toOutgoing`), so degrade to it rather than drop the message. Rate
+        // limits are excluded above — those retry via sendRetry.
+        void logger.error(
+          'discord/send:callout-fallback',
+          err instanceof Error ? err.message : String(err),
+        );
+        const fallback = content ? `${content} ${msg.text}` : msg.text;
+        try {
+          await channel.send(fallback);
+        } catch (fallbackErr) {
+          const fallbackRl = toRateLimitError(fallbackErr);
+          if (fallbackRl) throw fallbackRl;
+          throw fallbackErr;
+        }
       }
       return;
     }

--- a/src/providers/discord/embed.ts
+++ b/src/providers/discord/embed.ts
@@ -1,15 +1,13 @@
 // Discord embed limits — see https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
+import { clampText } from '../../core/clampText';
+
 export const EMBED_TITLE_MAX = 256;
 export const EMBED_DESCRIPTION_MAX = 4096;
 export const EMBED_FIELD_VALUE_MAX = 1024;
-const ELLIPSIS = '\n…';
 
-/** Truncate `text` to `max` chars, appending an ellipsis marker if truncated. */
-export function clampText(text: string, max: number): string {
-  if (text.length <= max) return text;
-  if (max <= ELLIPSIS.length) return text.slice(0, max);
-  return text.slice(0, max - ELLIPSIS.length) + ELLIPSIS;
-}
+// Re-exported so existing callers keep importing the clamp from the embed
+// module they already depend on; the implementation is shared with Slack.
+export { clampText };
 
 export const clampTitle = (text: string): string => clampText(text, EMBED_TITLE_MAX);
 export const clampDescription = (text: string): string => clampText(text, EMBED_DESCRIPTION_MAX);

--- a/src/providers/slack/adapter.ts
+++ b/src/providers/slack/adapter.ts
@@ -335,6 +335,7 @@ export class SlackProvider implements BridgeProvider {
             color: meta.hex,
             title: msg.callout.title ?? `${meta.emoji} ${meta.label}`,
             text: msg.callout.body,
+            mrkdwn_in: ['text'],
           },
         ],
       };

--- a/src/providers/slack/adapter.ts
+++ b/src/providers/slack/adapter.ts
@@ -14,6 +14,7 @@ import type {
 import { maestro } from '../../core/maestro';
 import { logger } from '../../core/logger';
 import { CALLOUT_META } from '../../core/callouts';
+import { clampAttachmentText, clampAttachmentTitle, clampMessageText } from './attachment';
 import { AgentNotFoundError, RateLimitError } from '../../core/errors';
 import { slackConfig } from './config';
 import { channelDb } from './channelsDb';
@@ -325,52 +326,76 @@ export class SlackProvider implements BridgeProvider {
     // becomes a single colored attachment (mrkdwn `text`, so a fenced table in
     // the body renders as code) with the mention riding in the top-level `text`
     // so the ping still fires; a plain message keeps today's `text` posting.
+    // Every field is clamped to Slack's limits (see ./attachment): an
+    // over-length attachment is truncated server-side with no marker, so we cut
+    // it ourselves and leave a visible `…`.
+    const plainPayload = (): { text: string } => ({
+      text: clampMessageText(mentionText ? `${mentionText} ${msg.text}` : msg.text),
+    });
+
     let payload: { text: string; attachments?: unknown[] };
     if (msg.callout) {
       const meta = CALLOUT_META[msg.callout.variant];
       payload = {
-        text: mentionText,
+        text: clampMessageText(mentionText),
         attachments: [
           {
             color: meta.hex,
-            title: msg.callout.title ?? `${meta.emoji} ${meta.label}`,
-            text: msg.callout.body,
+            title: clampAttachmentTitle(msg.callout.title ?? `${meta.emoji} ${meta.label}`),
+            text: clampAttachmentText(msg.callout.body),
             mrkdwn_in: ['text'],
           },
         ],
       };
     } else {
-      payload = {
-        text: mentionText ? `${mentionText} ${msg.text}` : msg.text,
-      };
+      payload = plainPayload();
     }
 
-    try {
-      // Resolve channel vs thread once; both branches share it and differ only
-      // in the postMessage payload.
-      if (isThreadTs(target.channelId)) {
-        // target is a thread_ts — look up parent channel
-        const convo = conversationDb.get(target.channelId);
-        if (!convo) {
-          // The thread is orphaned — its row was likely removed when the
-          // bound channel was disconnected, or the DB was reset. Log the
-          // mismatch specifically so operators can distinguish it from
-          // generic Slack/network errors before surfacing to the kernel.
-          void logger.error('slack/send:orphan-thread', `thread_ts=${target.channelId}`);
-          throw new Error(`No conversation found for thread_ts ${target.channelId}`);
-        }
-        await this.client.chat.postMessage({
-          channel: convo.channel_id,
-          thread_ts: target.channelId,
-          ...payload,
-        });
-      } else {
-        await this.client.chat.postMessage({ channel: target.channelId, ...payload });
+    // Resolve channel vs thread once; the rich post and its plaintext fallback
+    // share the destination and differ only in the payload.
+    let destination: { channel: string; thread_ts?: string };
+    if (isThreadTs(target.channelId)) {
+      // target is a thread_ts — look up parent channel
+      const convo = conversationDb.get(target.channelId);
+      if (!convo) {
+        // The thread is orphaned — its row was likely removed when the
+        // bound channel was disconnected, or the DB was reset. Log the
+        // mismatch specifically so operators can distinguish it from
+        // generic Slack/network errors before surfacing to the kernel.
+        void logger.error('slack/send:orphan-thread', `thread_ts=${target.channelId}`);
+        throw new Error(`No conversation found for thread_ts ${target.channelId}`);
       }
+      destination = { channel: convo.channel_id, thread_ts: target.channelId };
+    } else {
+      destination = { channel: target.channelId };
+    }
+
+    const client = this.client;
+    const post = (p: { text: string; attachments?: unknown[] }): Promise<unknown> =>
+      client.chat.postMessage({ ...destination, ...p });
+
+    try {
+      await post(payload);
     } catch (err) {
       const rl = toRateLimitError(err);
       if (rl) throw rl;
-      throw err;
+      // A rich attachment can fail on grounds plain text won't hit (malformed
+      // payload, an attachment-related scope, a field Slack rejects). `msg.text`
+      // holds a lossless `> [!VARIANT]` blockquote of the same content (see
+      // core/callouts.ts `toOutgoing`), so degrade to it rather than drop the
+      // message. Rate limits are excluded above — those retry via sendRetry.
+      if (!msg.callout) throw err;
+      void logger.error(
+        'slack/send:callout-fallback',
+        err instanceof Error ? err.message : String(err),
+      );
+      try {
+        await post(plainPayload());
+      } catch (fallbackErr) {
+        const fallbackRl = toRateLimitError(fallbackErr);
+        if (fallbackRl) throw fallbackRl;
+        throw fallbackErr;
+      }
     }
   }
 

--- a/src/providers/slack/adapter.ts
+++ b/src/providers/slack/adapter.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../core/types';
 import { maestro } from '../../core/maestro';
 import { logger } from '../../core/logger';
+import { CALLOUT_META } from '../../core/callouts';
 import { AgentNotFoundError, RateLimitError } from '../../core/errors';
 import { slackConfig } from './config';
 import { channelDb } from './channelsDb';
@@ -317,12 +318,35 @@ export class SlackProvider implements BridgeProvider {
   async send(target: ChannelTarget, msg: OutgoingMessage): Promise<void> {
     if (!this.client) throw new Error('Slack client not initialised');
 
-    let text = msg.text;
-    if (msg.mention && slackConfig.mentionUserId) {
-      text = `<@${slackConfig.mentionUserId}> ${text}`;
+    const mentionText =
+      msg.mention && slackConfig.mentionUserId ? `<@${slackConfig.mentionUserId}>` : '';
+
+    // Build the payload that differs between callout and plain posts. A callout
+    // becomes a single colored attachment (mrkdwn `text`, so a fenced table in
+    // the body renders as code) with the mention riding in the top-level `text`
+    // so the ping still fires; a plain message keeps today's `text` posting.
+    let payload: { text: string; attachments?: unknown[] };
+    if (msg.callout) {
+      const meta = CALLOUT_META[msg.callout.variant];
+      payload = {
+        text: mentionText,
+        attachments: [
+          {
+            color: meta.hex,
+            title: msg.callout.title ?? `${meta.emoji} ${meta.label}`,
+            text: msg.callout.body,
+          },
+        ],
+      };
+    } else {
+      payload = {
+        text: mentionText ? `${mentionText} ${msg.text}` : msg.text,
+      };
     }
 
     try {
+      // Resolve channel vs thread once; both branches share it and differ only
+      // in the postMessage payload.
       if (isThreadTs(target.channelId)) {
         // target is a thread_ts — look up parent channel
         const convo = conversationDb.get(target.channelId);
@@ -337,10 +361,10 @@ export class SlackProvider implements BridgeProvider {
         await this.client.chat.postMessage({
           channel: convo.channel_id,
           thread_ts: target.channelId,
-          text,
+          ...payload,
         });
       } else {
-        await this.client.chat.postMessage({ channel: target.channelId, text });
+        await this.client.chat.postMessage({ channel: target.channelId, ...payload });
       }
     } catch (err) {
       const rl = toRateLimitError(err);

--- a/src/providers/slack/attachment.ts
+++ b/src/providers/slack/attachment.ts
@@ -1,0 +1,33 @@
+/**
+ * Slack attachment field limits.
+ *
+ * Slack's limits are less crisply documented than Discord's. Only the top-level
+ * message `text` cap is official: 40,000 characters, per the 2018 truncation
+ * changelog (https://docs.slack.dev/changelog/2018-truncating-really-long-messages/).
+ * Secondary attachments are a legacy surface and Slack publishes no hard caps
+ * for `title` / `text`; the widely-reproduced observed behavior is that
+ * attachment text collapses behind "Show more" past ~700 chars and is truncated
+ * server-side around 8,000.
+ *
+ * We therefore clamp to the *observed* truncation point rather than the official
+ * message cap: clamping ourselves appends a visible `…` marker, whereas letting
+ * Slack truncate drops the tail silently with no indication content was lost.
+ * `ATTACHMENT_TITLE_MAX` is a self-imposed presentation cap (a title renders on
+ * one line, so a multi-KB title is a layout bug, not a payload error) chosen to
+ * match Discord's 256 for cross-provider consistency — it is not a Slack-imposed
+ * limit.
+ */
+
+import { clampText } from '../../core/clampText';
+
+/** Observed server-side truncation point for attachment `text`. */
+export const ATTACHMENT_TEXT_MAX = 8000;
+/** Self-imposed single-line title cap (Slack documents no limit). */
+export const ATTACHMENT_TITLE_MAX = 256;
+/** Official cap on a message's top-level `text` field. */
+export const MESSAGE_TEXT_MAX = 40000;
+
+export const clampAttachmentTitle = (text: string): string =>
+  clampText(text, ATTACHMENT_TITLE_MAX);
+export const clampAttachmentText = (text: string): string => clampText(text, ATTACHMENT_TEXT_MAX);
+export const clampMessageText = (text: string): string => clampText(text, MESSAGE_TEXT_MAX);


### PR DESCRIPTION
## Summary

Adds GitHub-style **callout embeds**. Any `> [!TYPE]` block (NOTE / TIP / IMPORTANT / WARNING / CAUTION) in an agent's output is auto-detected and rendered as a **colored Discord embed** / **colored Slack attachment**, interleaved with the surrounding prose via multi-message sends (each prose block and each callout is its own message, emitted in original order).

## Phases / Commits

1. `1c37017` — fence-aware callout splitter, `toOutgoing` composer, and `CALLOUT_META`
2. `c556043` — route push + reply paths through `toOutgoing`; share the `RateLimitError` backoff
3. `e8c03cd` — render Discord colored embed for `msg.callout`
4. `577836c` — render Slack colored attachment for `msg.callout`
5. `67f7d55` — docs: Discord/Slack callout rendering, push `renderTables` change, Teams/rooms fallback

(plus `f2d6cef` — docs: implementation plan)

## Binding decisions

- **#6 — Push path now ALSO applies `renderTables` (BEHAVIOR CHANGE).** Previously the `/api/send` push path did not run table rendering; routing it through `toOutgoing` means pushed messages now get the same markdown-table rendering the reply path already had. Called out prominently because it changes existing push output.
- **#5 — `renderTables` is applied to callout bodies too**, not just top-level prose, so tables inside a callout render consistently.
- **#7 — Uppercase-only marker, alone on its own line (GitHub-exact).** `> [!NOTE]` opens a callout only when the tag is uppercase and the marker stands alone on the line; `> [!note]` or `> [!NOTE] trailing text` is treated as plain text.

## Review requirement addressed

The `queue.ts` reply path now **shares the `RateLimitError` backoff with `api.ts`** (single `sendWithRetry` helper) — the retry asymmetry between push and reply is gone.

## Scope

- **Rooms (`bus.ts`)** and the **Teams Adaptive Card** rendering are intentionally **follow-up**, not in this PR. Teams/rooms fall back to the blockquote text form.

## Test status

- Full suite: **454 pass / 0 fail** (`npm test`)
- `npx tsc --noEmit`: **0 errors**
- New suites verified green: `callouts.test`, `discord-callout.test`, `slack-callout.test`

🤖 Generated with Claude Code
