### PR TITLE
test(discord): regression coverage for PR #51 thread binding and agent sort

### DIFF
--- a/src/__tests__/agents-command.test.ts
+++ b/src/__tests__/agents-command.test.ts
@@ -519,6 +519,69 @@ test('autocomplete filters agents by name', async () => {
   assert.equal(items[0].value, 'a-1');
 });
 
+test('autocomplete returns agents sorted by name', async () => {
+  const { maestro } = await import('../core/maestro');
+  // Deliberately unsorted, and not sorted by id either.
+  mock.method(maestro, 'listAgents', async () => [
+    { id: 'a-3', name: 'Zulu', toolType: 'claude', cwd: '/' },
+    { id: 'a-1', name: 'Alpha', toolType: 'claude', cwd: '/' },
+    { id: 'a-2', name: 'Mike', toolType: 'openai', cwd: '/' },
+  ]);
+
+  const interaction = {
+    options: { getFocused: () => '' },
+    respond: mock.fn(async () => {}),
+  } as any;
+
+  await autocomplete(interaction);
+
+  const items = interaction.respond.mock.calls[0].arguments[0] as Array<{
+    name: string;
+    value: string;
+  }>;
+  assert.deepEqual(
+    items.map((i) => i.value),
+    ['a-1', 'a-2', 'a-3'],
+    'entries should be ordered by agent name, not by input order',
+  );
+});
+
+test('autocomplete sorts before truncating to the 25-item Discord limit', async () => {
+  const { maestro } = await import('../core/maestro');
+  // 30 agents supplied in reverse name order. Discord caps choices at 25, so
+  // if truncation happened before sorting the alphabetically-first agents
+  // would be dropped.
+  const agents = Array.from({ length: 30 }, (_, idx) => {
+    const n = 30 - idx;
+    return {
+      id: `a-${String(n).padStart(2, '0')}`,
+      name: `Agent-${String(n).padStart(2, '0')}`,
+      toolType: 'claude',
+      cwd: '/',
+    };
+  });
+  mock.method(maestro, 'listAgents', async () => agents);
+
+  const interaction = {
+    options: { getFocused: () => '' },
+    respond: mock.fn(async () => {}),
+  } as any;
+
+  await autocomplete(interaction);
+
+  const items = interaction.respond.mock.calls[0].arguments[0] as Array<{
+    name: string;
+    value: string;
+  }>;
+  assert.equal(items.length, 25, 'must respect the Discord 25-choice cap');
+  assert.equal(items[0].value, 'a-01', 'lowest-sorting agent must survive truncation');
+  assert.equal(items[24].value, 'a-25');
+  assert.ok(
+    !items.some((i) => i.value === 'a-30'),
+    'highest-sorting agents should be the ones truncated away',
+  );
+});
+
 test('autocomplete returns empty on error', async () => {
   const { maestro } = await import('../core/maestro');
   mock.method(maestro, 'listAgents', async () => {

--- a/src/__tests__/auto-run-command.test.ts
+++ b/src/__tests__/auto-run-command.test.ts
@@ -387,3 +387,48 @@ test('auto-run autocomplete returns empty when channel is not registered', async
   await autocomplete(i as unknown as Parameters<typeof autocomplete>[0]);
   assert.deepEqual(responded[0], []);
 });
+
+test('auto-run autocomplete resolves the agent from the parent channel inside a thread', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-run-thread-'));
+  try {
+    await fs.writeFile(path.join(tmp, 'plan.md'), '#');
+
+    // Only the parent channel is bound; the thread itself has no binding.
+    const { channelDb } = await import('../providers/discord/channelsDb');
+    mock.method(channelDb, 'get', (id: string) =>
+      id === 'parent-1'
+        ? { channel_id: 'parent-1', agent_id: 'agent-1', agent_name: 'TestBot' }
+        : undefined,
+    );
+
+    const { maestro } = await import('../core/maestro');
+    const showAgent = mock.method(maestro, 'showAgent', async () => ({
+      id: 'agent-1',
+      name: 'TestBot',
+      toolType: 'claude',
+      cwd: '/proj',
+      autoRunFolderPath: tmp,
+    }));
+
+    const responded: Array<Array<{ name: string; value: string }>> = [];
+    const i = {
+      channelId: 'thread-1',
+      channel: { isThread: () => true, parentId: 'parent-1' },
+      options: { getFocused: () => ({ name: 'doc', value: '' }) },
+      respond: mock.fn(async (items: Array<{ name: string; value: string }>) => {
+        responded.push(items);
+      }),
+    };
+
+    await autocomplete(i as unknown as Parameters<typeof autocomplete>[0]);
+
+    // Before the parent-channel fallback this returned [] because the thread
+    // id had no binding of its own.
+    assert.equal(showAgent.mock.callCount(), 1, 'should resolve the parent binding agent');
+    assert.equal(showAgent.mock.calls[0].arguments[0], 'agent-1');
+    const values = responded[0].map((x) => x.value);
+    assert.deepEqual(values, ['plan.md']);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/src/__tests__/discord-channelsDb.test.ts
+++ b/src/__tests__/discord-channelsDb.test.ts
@@ -1,0 +1,117 @@
+import test, { afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { channelDb, getChannelInfoForInteraction } from '../providers/discord/channelsDb';
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+// --- Helpers ---
+
+const BINDING = {
+  provider: 'discord',
+  channel_id: 'parent-1',
+  guild_id: 'guild-1',
+  agent_id: 'agent-1',
+  session_id: null,
+} as unknown as ReturnType<typeof channelDb.get>;
+
+function makeInteraction(opts: {
+  channelId: string;
+  isThread?: boolean;
+  parentId?: string | null;
+  noChannel?: boolean;
+}) {
+  return {
+    channelId: opts.channelId,
+    channel: opts.noChannel
+      ? null
+      : {
+          isThread: () => opts.isThread ?? false,
+          parentId: opts.parentId ?? null,
+        },
+  } as unknown as Parameters<typeof getChannelInfoForInteraction>[0];
+}
+
+// --- getChannelInfoForInteraction (parent-channel fallback) ---
+
+test('resolves a direct binding without consulting the parent channel', () => {
+  const get = mock.method(channelDb, 'get', (id: string) =>
+    id === 'ch-1' ? BINDING : undefined,
+  );
+
+  const info = getChannelInfoForInteraction(makeInteraction({ channelId: 'ch-1' }));
+
+  assert.equal(info, BINDING);
+  // Only the direct lookup should have happened.
+  assert.equal(get.mock.callCount(), 1);
+  assert.equal(get.mock.calls[0].arguments[0], 'ch-1');
+});
+
+test('falls back to the parent channel binding when invoked inside a thread', () => {
+  // The thread itself is unbound; only its parent carries the agent binding.
+  const get = mock.method(channelDb, 'get', (id: string) =>
+    id === 'parent-1' ? BINDING : undefined,
+  );
+
+  const info = getChannelInfoForInteraction(
+    makeInteraction({ channelId: 'thread-1', isThread: true, parentId: 'parent-1' }),
+  );
+
+  assert.equal(info, BINDING, 'thread should inherit the parent channel binding');
+  assert.equal(get.mock.callCount(), 2);
+  assert.equal(get.mock.calls[0].arguments[0], 'thread-1');
+  assert.equal(get.mock.calls[1].arguments[0], 'parent-1');
+});
+
+test('prefers the thread own binding over the parent channel', () => {
+  const threadBinding = { ...BINDING, channel_id: 'thread-1', agent_id: 'agent-thread' };
+  mock.method(channelDb, 'get', (id: string) =>
+    id === 'thread-1' ? threadBinding : BINDING,
+  );
+
+  const info = getChannelInfoForInteraction(
+    makeInteraction({ channelId: 'thread-1', isThread: true, parentId: 'parent-1' }),
+  );
+
+  assert.equal(info?.agent_id, 'agent-thread');
+});
+
+test('returns undefined for an unbound non-thread channel', () => {
+  mock.method(channelDb, 'get', () => undefined);
+
+  const info = getChannelInfoForInteraction(makeInteraction({ channelId: 'ch-1' }));
+
+  assert.equal(info, undefined);
+});
+
+test('returns undefined when neither the thread nor its parent is bound', () => {
+  mock.method(channelDb, 'get', () => undefined);
+
+  const info = getChannelInfoForInteraction(
+    makeInteraction({ channelId: 'thread-1', isThread: true, parentId: 'parent-1' }),
+  );
+
+  assert.equal(info, undefined);
+});
+
+test('returns undefined for a thread with no parentId', () => {
+  mock.method(channelDb, 'get', () => undefined);
+
+  const info = getChannelInfoForInteraction(
+    makeInteraction({ channelId: 'thread-1', isThread: true, parentId: null }),
+  );
+
+  assert.equal(info, undefined);
+});
+
+test('tolerates an interaction with no resolvable channel', () => {
+  mock.method(channelDb, 'get', () => undefined);
+
+  assert.doesNotThrow(() => {
+    const info = getChannelInfoForInteraction(
+      makeInteraction({ channelId: 'ch-1', noChannel: true }),
+    );
+    assert.equal(info, undefined);
+  });
+});


### PR DESCRIPTION
Follow-up to #51 (merged as `77245d2`). Codex review flagged two of the four fixes as merged without direct regression tests. This adds them.

**Tests only — no source changes.**

## Fix 2 — parent-channel binding in threads

New `src/__tests__/discord-channelsDb.test.ts` unit-tests `getChannelInfoForInteraction`:
- direct binding resolves without a parent lookup
- unbound thread falls back to its parent channel binding
- a thread's own binding wins over the parent's
- unbound channel / unbound thread+parent / thread with no `parentId` / interaction with no channel

Plus an integration test in `auto-run-command.test.ts` covering the `/auto-run` autocomplete path — this was the genuinely uncovered one. (`gist` already had an equivalent test.)

## Fix 4 — sorted agents list

In `agents-command.test.ts`:
- `/agents` autocomplete orders results by name, not input order
- sorting happens **before** the 25-choice Discord cap, so alphabetically-first agents aren't truncated away — the failure mode a naive slice-then-sort would introduce

## Verification

Mutation-tested: reverting either fix in the source makes these tests fail (confirmed 5 failures, then restored). Not just passing tests — tests that actually bite.

Suite: **268 passing**, up from 258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded autocomplete coverage to verify alphabetical ordering and correct handling of the 25-choice limit.
  * Added coverage for resolving agents through a thread’s parent channel.
  * Added validation for channel binding resolution across direct channels, threads, parent fallbacks, and missing channel data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->