### PR TITLE
fix: port PR #51 Discord fixes to rc (+ Telegram gistUrl follow-up)

### DIFF
--- a/src/__tests__/gist-command.test.ts
+++ b/src/__tests__/gist-command.test.ts
@@ -43,6 +43,33 @@ test('gist rejects channels not connected to an agent', async () => {
   assert.ok(reply.content.includes('not connected to an agent'));
 });
 
+test('gist resolves the parent channel binding when run inside a thread', async () => {
+  const { channelDb } = await import('../providers/discord/channelsDb');
+  mock.method(channelDb, 'get', (channelId: string) =>
+    channelId === 'parent-1'
+      ? { channel_id: 'parent-1', agent_id: 'agent-1', agent_name: 'TestBot' }
+      : undefined,
+  );
+
+  const { maestro } = await import('../core/maestro');
+  const createGist = mock.method(maestro, 'createGist', async () => ({
+    success: true,
+    agentId: 'agent-1',
+    gistUrl: 'https://gist.example/abc',
+  }));
+
+  const i = makeInteraction();
+  i.channelId = 'thread-1';
+  (i as unknown as { channel: unknown }).channel = {
+    isThread: () => true,
+    parentId: 'parent-1',
+  };
+  await execute(i as unknown as Parameters<typeof execute>[0]);
+
+  assert.equal(i.reply.mock.calls.length, 0);
+  assert.equal(createGist.mock.calls[0].arguments[0], 'agent-1');
+});
+
 test('gist publishes and renders an embed with the gist url', async () => {
   const { channelDb } = await import('../providers/discord/channelsDb');
   mock.method(channelDb, 'get', () => ({
@@ -53,8 +80,9 @@ test('gist publishes and renders an embed with the gist url', async () => {
 
   const { maestro } = await import('../core/maestro');
   mock.method(maestro, 'createGist', async () => ({
-    url: 'https://gist.example/abc',
-    id: 'abc',
+    success: true,
+    agentId: 'agent-1',
+    gistUrl: 'https://gist.example/abc',
   }));
 
   const i = makeInteraction({ description: 'desc', public: true });

--- a/src/__tests__/messageCreate.test.ts
+++ b/src/__tests__/messageCreate.test.ts
@@ -58,6 +58,19 @@ test('handleMessageCreate ignores bot messages', async () => {
   assert.equal(enqueued, 0);
 });
 
+test('handleMessageCreate ignores system messages (e.g. thread rename)', async () => {
+  let enqueued = 0;
+  const handler = createMessageCreateHandler(
+    createDeps(() => {
+      enqueued += 1;
+    }),
+  );
+
+  // A thread rename arrives as a system message whose content is the new name.
+  await handler(makeMessage({ system: true, content: 'renamed-thread' }) as any);
+  assert.equal(enqueued, 0);
+});
+
 test('handleMessageCreate ignores DMs', async () => {
   let enqueued = 0;
   const handler = createMessageCreateHandler(

--- a/src/core/maestro.ts
+++ b/src/core/maestro.ts
@@ -122,8 +122,9 @@ export interface MaestroAgentDetail extends MaestroAgent {
 }
 
 export interface GistResult {
-  url: string;
-  id: string;
+  success: boolean;
+  agentId: string;
+  gistUrl: string;
   [key: string]: unknown;
 }
 

--- a/src/providers/discord/channelsDb.ts
+++ b/src/providers/discord/channelsDb.ts
@@ -1,3 +1,4 @@
+import type { AutocompleteInteraction, ChatInputCommandInteraction } from 'discord.js';
 import { channelDb as core, type AgentChannel } from '../../core/db';
 
 /**
@@ -30,5 +31,21 @@ export const channelDb = {
     return core.listByGuild(guildId);
   },
 };
+
+/**
+ * Resolve the agent binding for an interaction's channel, falling back to the
+ * parent channel when the interaction happens inside a thread (agent sessions
+ * live in threads, but bindings are keyed on the parent channel).
+ */
+export function getChannelInfoForInteraction(
+  interaction: ChatInputCommandInteraction | AutocompleteInteraction,
+): AgentChannel | undefined {
+  const direct = channelDb.get(interaction.channelId);
+  if (direct) return direct;
+  if (interaction.channel?.isThread() && interaction.channel.parentId) {
+    return channelDb.get(interaction.channel.parentId);
+  }
+  return undefined;
+}
 
 export type { AgentChannel } from '../../core/db';

--- a/src/providers/discord/commands/agents.ts
+++ b/src/providers/discord/commands/agents.ts
@@ -70,9 +70,9 @@ export async function autocomplete(interaction: AutocompleteInteraction): Promis
 
   try {
     const agents = await maestro.listAgents();
-    const filtered = agents.filter(
-      (a) => a.name.toLowerCase().includes(focused) || a.id.toLowerCase().includes(focused),
-    );
+    const filtered = agents
+      .filter((a) => a.name.toLowerCase().includes(focused) || a.id.toLowerCase().includes(focused))
+      .sort((a, b) => a.name.localeCompare(b.name));
     await interaction.respond(
       filtered.slice(0, 25).map((a) => ({ name: `${a.name} (${a.toolType})`, value: a.id })),
     );

--- a/src/providers/discord/commands/auto-run.ts
+++ b/src/providers/discord/commands/auto-run.ts
@@ -5,7 +5,7 @@ import {
   ChatInputCommandInteraction,
   SlashCommandBuilder,
 } from 'discord.js';
-import { channelDb } from '../channelsDb';
+import { getChannelInfoForInteraction } from '../channelsDb';
 import { maestro } from '../../../core/maestro';
 
 export const data = new SlashCommandBuilder()
@@ -71,7 +71,7 @@ export async function autocomplete(interaction: AutocompleteInteraction): Promis
   const focused = interaction.options.getFocused(true);
   if (focused.name !== 'doc') return interaction.respond([]);
 
-  const channelInfo = channelDb.get(interaction.channelId);
+  const channelInfo = getChannelInfoForInteraction(interaction);
   if (!channelInfo) return interaction.respond([]);
 
   const folder = await getAgentFolder(channelInfo.agent_id);
@@ -103,7 +103,7 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
   const sub = interaction.options.getSubcommand();
   if (sub !== 'start') return;
 
-  const channelInfo = channelDb.get(interaction.channelId);
+  const channelInfo = getChannelInfoForInteraction(interaction);
   if (!channelInfo) {
     await interaction.reply({
       content: '❌ This channel is not connected to an agent. Use `/agents new` first.',

--- a/src/providers/discord/commands/gist.ts
+++ b/src/providers/discord/commands/gist.ts
@@ -3,7 +3,7 @@ import {
   EmbedBuilder,
   SlashCommandBuilder,
 } from 'discord.js';
-import { channelDb } from '../channelsDb';
+import { getChannelInfoForInteraction } from '../channelsDb';
 import { maestro } from '../../../core/maestro';
 
 export const data = new SlashCommandBuilder()
@@ -20,7 +20,7 @@ export const data = new SlashCommandBuilder()
   );
 
 export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
-  const channelInfo = channelDb.get(interaction.channelId);
+  const channelInfo = getChannelInfoForInteraction(interaction);
   if (!channelInfo) {
     await interaction.reply({
       content: '❌ This channel is not connected to an agent. Use `/agents new` first.',
@@ -47,8 +47,8 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
   const embed = new EmbedBuilder()
     .setColor(0x57f287)
     .setTitle(`📎 Gist published — ${channelInfo.agent_name}`)
-    .setURL(result.url)
-    .setDescription(`[Open gist](${result.url})\nVisibility: **${visibility}**`);
+    .setURL(result.gistUrl)
+    .setDescription(`[Open gist](${result.gistUrl})\nVisibility: **${visibility}**`);
 
   await interaction.editReply({ embeds: [embed] });
 }

--- a/src/providers/discord/messageCreate.ts
+++ b/src/providers/discord/messageCreate.ts
@@ -53,6 +53,7 @@ export function createMessageCreateHandler(deps: MessageCreateDeps) {
 
   return async function handleMessageCreate(message: Message): Promise<void> {
     if (message.author.bot) return;
+    if (message.system) return;
     if (!message.guild) return;
 
     if (!message.content.trim() && message.attachments.size === 0) return;

--- a/src/providers/telegram/commands/gist.ts
+++ b/src/providers/telegram/commands/gist.ts
@@ -31,7 +31,7 @@ export async function execute(ctx: TelegramCommandContext): Promise<void> {
   const visibility = isPublic ? 'public' : 'private';
   await ctx.reply(
     `📎 Gist published — ${ctx.boundAgentName}\n` +
-      `${result.url}\n` +
+      `${result.gistUrl}\n` +
       `Visibility: ${visibility}`,
   );
 }


### PR DESCRIPTION
Ports the four fixes from #51 (merged to main as `77245d2`) onto `rc`, where active development actually happens. Without this they'd be silently missing from every rc-channel release.

## Commits

1. **`2b90162`** — clean cherry-pick of `77245d2`, no conflicts. rc had only touched these files via the `console.*`→`KernelLogger` refactor on non-overlapping lines, and never touched gist code at all. Attribution to @scriptease preserved.
2. **Telegram `gistUrl` fixup** — see below.

## The Telegram issue this surfaced

The cherry-pick renames `GistResult.url` → `gistUrl`. **rc has a Telegram provider that main does not**, and its `/gist` handler read `result.url`.

This does *not* fail `tsc` — `GistResult` has an `[key: string]: unknown` index signature, so `result.url` resolves to `unknown` rather than erroring. I confirmed `npx tsc --noEmit` passes clean with the stale field in place. The break would have been runtime-only: Telegram posting `undefined` as the gist URL.

Worth flagging as a general hazard — that index signature means any future field rename on `GistResult` will pass typecheck and fail in production.

## Tests

**498/498 passing** on rc.

## Out of scope / follow-ups

- Telegram's own `commands/agents.ts` listing is unsorted, i.e. Fix 4's equivalent is missing there. Pre-existing, not introduced by this port — left alone deliberately.
- The regression tests in #64 (against main) will need the same port to rc once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)