### PR TITLE
feat(discord): route thread replies on agent pushes back into the session (#63)

### DIFF
--- a/AGENTS-providers.md
+++ b/AGENTS-providers.md
@@ -40,12 +40,13 @@ Defined in `src/core/types.ts`. Every provider exports a class implementing this
 | `start(ctx: KernelContext)`     | yes      | Connect to the platform, register event handlers, call `ctx.enqueue(msg)` per inbound message |
 | `stop()`                        | yes      | Disconnect cleanly; called on graceful shutdown                                      |
 | `resolveConversation(message)`  | yes      | Look up the maestro agent + session bound to this conversation; return null to drop  |
-| `send(target, msg)`             | yes      | Post a message into a channel/thread; called by the kernel queue                     |
+| `send(target, msg)`             | yes      | Post a message into a channel/thread; called by the kernel queue. May return a `SendResult` carrying the posted `messageId` (Discord does; returning `void` stays valid) |
 | `findOrCreateAgentChannel(id)`  | yes      | Look up or create the platform channel bound to an agent (used by `/api/send`)       |
 | `isReady()`                     | yes      | Provider readiness for `/api/health`                                                 |
 | `react?(target, emoji)`         | optional | Queue/transcription indicator (e.g. `⏳`, `🎧`)                                      |
 | `sendTyping?(target)`           | optional | Typing indicator while the agent thinks                                              |
 | `sendAs?(target, identity, msg)`| optional | Post under a distinct per-message persona (multi-agent rooms) — see below            |
+| `recordPushedMessage?(record)`  | optional | Remember a message pushed via `/api/send` (message id → agent + session) so a reply anchored on it can be adopted into that session. Implement only if the platform lets an inbound reply be traced back to the message it answers |
 
 The kernel calls `react` and `sendTyping` if they exist; safe to omit when the platform has no analogue.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ This repo is **Maestro Relay** — a chat-platform-to-Maestro bridge built aroun
 
 ### Discord provider
 
-Lives under `src/providers/discord/` (`adapter.ts`, `messageCreate.ts`, `voice.ts`, `commands/`, `deploy.ts`, `channelsDb.ts`, `threadsDb.ts`, `embed.ts`, `config.ts`). For Discord-specific runtime behavior, env vars, slash commands, and bot setup see [docs/discord.md](docs/discord.md). Voice transcription is documented in [docs/voice.md](docs/voice.md).
+Lives under `src/providers/discord/` (`adapter.ts`, `messageCreate.ts`, `voice.ts`, `commands/`, `deploy.ts`, `channelsDb.ts`, `threadsDb.ts`, `pushedMessagesDb.ts`, `embed.ts`, `config.ts`). Threads started on an agent-pushed message are adopted into the pushing agent's session — `pushedMessagesDb.ts` is the anchor registry, `messageCreate.ts` the adopt-on-miss path. For Discord-specific runtime behavior, env vars, slash commands, and bot setup see [docs/discord.md](docs/discord.md). Voice transcription is documented in [docs/voice.md](docs/voice.md).
 
 ### Slack provider
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,6 +22,10 @@ maestro-relay send --agent <agent-id> --provider discord --message "Hello from M
 # e.g. DISCORD_MENTION_USER_ID for the Discord provider)
 maestro-relay send --agent <agent-id> --message "Build complete!" --mention
 
+# Send as part of a session — a reply thread on this message continues that
+# session instead of starting a new one (Discord; see "Answerable pushes")
+maestro-relay send --agent <agent-id> --session <session-id> --message "Deploy done — questions?"
+
 # Use a custom port
 maestro-relay send --agent <agent-id> --message "Hello" --port 4000
 
@@ -65,13 +69,42 @@ Request: `Content-Type: application/json`
   "agentId": "string",
   "message": "string",
   "mention": false,
-  "provider": "discord"
+  "provider": "discord",
+  "sessionId": "string"
 }
 ```
 
 `provider` is optional and defaults to `"discord"`. Must be a name listed in `ENABLED_PROVIDERS`.
 
 `mention` is rendered by the provider in a platform-appropriate way (Discord prepends `<@DISCORD_MENTION_USER_ID>` to the first part of a multi-part message).
+
+`sessionId` is optional — see [Answerable pushes](#answerable-pushes).
+
+Response:
+
+```json
+{
+  "success": true,
+  "channelId": "123456789",
+  "messageIds": ["987654321"]
+}
+```
+
+`messageIds` lists the platform message ids of the posted parts, in order, for providers that report them (Discord). Providers that don't return an empty array.
+
+#### Answerable pushes
+
+An agent-initiated push is a dead end by default: the bridge posts it, and a human answering it in the channel has nothing to route the answer back to.
+
+Passing `sessionId` fixes that for **Discord**. The bridge records each posted message against `(agentId, sessionId)`, and when someone **starts a thread on that message**, the reply is routed into that same maestro session — the agent picks the conversation up where it left off, with its context intact. No thread bookkeeping is needed on the caller's side; the binding is established the first time somebody replies.
+
+Notes:
+
+- **Threads only.** An *inline* reply in the parent channel is not routed: the channel and the session would then share one processing queue, interleaving windup traffic with ordinary channel traffic. Reply in a thread on the message.
+- The thread binds to whoever replied first, matching the ownership rule for mention-created threads.
+- Without `sessionId`, a thread on a pushed message still reaches the right **agent** — it just opens a fresh session.
+- Anchors are kept for **30 days**, then purged. Only ids are stored, never message content.
+- Non-Discord providers accept and ignore `sessionId` today.
 
 #### Rich rendering
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,7 +70,8 @@ Request: `Content-Type: application/json`
   "message": "string",
   "mention": false,
   "provider": "discord",
-  "sessionId": "string"
+  "sessionId": "string",
+  "userId": "string"
 }
 ```
 
@@ -78,7 +79,7 @@ Request: `Content-Type: application/json`
 
 `mention` is rendered by the provider in a platform-appropriate way (Discord prepends `<@DISCORD_MENTION_USER_ID>` to the first part of a multi-part message).
 
-`sessionId` is optional — see [Answerable pushes](#answerable-pushes).
+`sessionId` and `userId` are optional — see [Answerable pushes](#answerable-pushes).
 
 Response:
 
@@ -98,13 +99,15 @@ An agent-initiated push is a dead end by default: the bridge posts it, and a hum
 
 Passing `sessionId` fixes that for **Discord**. The bridge records each posted message against `(agentId, sessionId)`, and when someone **starts a thread on that message**, the reply is routed into that same maestro session — the agent picks the conversation up where it left off, with its context intact. No thread bookkeeping is needed on the caller's side; the binding is established the first time somebody replies.
 
+**Who may continue the session.** Picking a session back up means reading and extending its context, so a push only hands its session to a vetted user: `userId` (the platform user id allowed to answer), falling back to `DISCORD_MENTION_USER_ID` when omitted. A reply thread opened by that user inherits `sessionId`; a reply from anyone else is refused and leaves the thread unbound, so the rightful owner can still claim it (a bystander can always @-mention the bot in the channel to get a session of their own). If neither `userId` nor a configured mention user exists, the anchor has no owner and a reply thread simply starts a **fresh** session with the right agent.
+
 Notes:
 
 - **Threads only.** An *inline* reply in the parent channel is not routed: the channel and the session would then share one processing queue, interleaving windup traffic with ordinary channel traffic. Reply in a thread on the message.
-- The thread binds to whoever replied first, matching the ownership rule for mention-created threads.
+- The thread binds to whoever replied first (subject to the ownership check above), matching the ownership rule for mention-created threads.
 - Without `sessionId`, a thread on a pushed message still reaches the right **agent** — it just opens a fresh session.
 - Anchors are kept for **30 days**, then purged. Only ids are stored, never message content.
-- Non-Discord providers accept and ignore `sessionId` today.
+- Non-Discord providers accept and ignore `sessionId` / `userId` today.
 
 #### Rich rendering
 

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -87,6 +87,16 @@ npm run deploy-commands
 - **Usage stats** are appended below each agent reply (tokens, cost, context %).
 - **Markdown tables** in agent replies are rendered as aligned, fenced ASCII tables so they display correctly (Discord has no native table syntax). See [architecture.md → Output rendering](architecture.md#output-rendering).
 
+## Answering an agent's push
+
+When an agent pushes a message on its own (`POST /api/send`, `maestro-relay send`), **starting a thread on that message** makes it answerable: the reply is routed to the agent that posted it, and — when the push carried a `sessionId` — into that same maestro session, so the agent continues with its context instead of starting cold.
+
+How it works: the bridge records the id of every message it pushes, and Discord gives a thread created from a message the same id as that message. So a thread the bridge has never seen is looked up in that registry; a hit binds the thread on the spot (agent + inherited session, owner = the first replier) and the turn flows through the normal thread path.
+
+- **Threads only.** An inline reply in the parent channel is *not* routed — it would put windup traffic and ordinary channel traffic on the same processing queue. Use "Create Thread" on the message.
+- Push anchors hold **ids only** (no message content) and are purged after **30 days**; disconnecting an agent from a channel drops that channel's anchors immediately.
+- See [api.md → Answerable pushes](api.md#answerable-pushes) for the request shape.
+
 ## Callout embeds
 
 Outbound text (agent replies and `/api/send` pushes) is scanned for **GitHub alert callouts** — a blockquote whose first line is `> [!NOTE]` (or `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`). The marker must be **uppercase** and **alone on its line** (GitHub-exact syntax); a plain `> quote` stays a normal grey Discord blockquote. Each detected callout is rendered as a **colored Discord embed emitted as its own message**, in order with the surrounding prose, so it visually stands apart from ordinary text.

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -93,6 +93,8 @@ When an agent pushes a message on its own (`POST /api/send`, `maestro-relay send
 
 How it works: the bridge records the id of every message it pushes, and Discord gives a thread created from a message the same id as that message. So a thread the bridge has never seen is looked up in that registry; a hit binds the thread on the spot (agent + inherited session, owner = the first replier) and the turn flows through the normal thread path.
 
+- **Only the addressed user inherits the session.** The anchor also records who may answer — the push's `userId`, or `DISCORD_MENTION_USER_ID` when it carries none. A thread opened by that user continues the pushed session; a reply from any other member is refused (the thread stays unbound and claimable, and they can still @-mention the bot for a session of their own). With no `userId` and no `DISCORD_MENTION_USER_ID`, a reply thread reaches the right agent in a **fresh** session. Without this gate, anyone who can open a thread on a push could take over the referenced session and read its context.
+
 - **Threads only.** An inline reply in the parent channel is *not* routed — it would put windup traffic and ordinary channel traffic on the same processing queue. Use "Create Thread" on the message.
 - Push anchors hold **ids only** (no message content) and are purged after **30 days**; disconnecting an agent from a channel drops that channel's anchors immediately.
 - See [api.md → Answerable pushes](api.md#answerable-pushes) for the request shape.

--- a/src/__tests__/db-migrations.test.ts
+++ b/src/__tests__/db-migrations.test.ts
@@ -128,10 +128,15 @@ test('ensureDiscordPushedMessagesTable creates the anchor table and is safe to r
 
   assert.deepEqual(
     cols.map((c) => c.name).sort(),
-    ['agent_id', 'channel_id', 'created_at', 'message_id', 'session_id'],
+    ['agent_id', 'channel_id', 'created_at', 'message_id', 'owner_user_id', 'session_id'],
   );
   assert.equal(byName.get('message_id')!.pk, 1, 'message_id is the primary key');
   assert.equal(byName.get('session_id')!.notnull, 0, 'session_id is nullable');
+  assert.equal(
+    byName.get('owner_user_id')!.notnull,
+    0,
+    'owner_user_id is nullable — an anchor may have no vetted owner',
+  );
 
   // The retention purge filters on created_at; it must be indexed.
   const indexes = database
@@ -159,4 +164,46 @@ test('runMigrations creates discord_pushed_messages on a legacy database', () =>
     .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='discord_pushed_messages'")
     .get() as { name?: string } | undefined;
   assert.equal(table?.name, 'discord_pushed_messages');
+});
+
+test('runMigrations backfills owner_user_id on a pre-gate discord_pushed_messages table', () => {
+  const database = new Database(':memory:');
+  database.exec(`
+    CREATE TABLE agent_channels (
+      channel_id TEXT PRIMARY KEY,
+      guild_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      agent_name TEXT NOT NULL,
+      session_id TEXT,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch())
+    )
+  `);
+  // The shape the table had before session handover was gated on an owner.
+  database.exec(`
+    CREATE TABLE discord_pushed_messages (
+      message_id  TEXT PRIMARY KEY,
+      channel_id  TEXT NOT NULL,
+      agent_id    TEXT NOT NULL,
+      session_id  TEXT,
+      created_at  INTEGER NOT NULL DEFAULT (unixepoch())
+    )
+  `);
+  database
+    .prepare(
+      'INSERT INTO discord_pushed_messages (message_id, channel_id, agent_id, session_id) VALUES (?, ?, ?, ?)',
+    )
+    .run('m-1', 'ch-1', 'agent-1', 'session-1');
+
+  runMigrations(database);
+  // Idempotent: a second run must not trip over the now-existing column.
+  runMigrations(database);
+
+  const cols = database
+    .prepare("PRAGMA table_info('discord_pushed_messages')")
+    .all() as Array<{ name: string }>;
+  assert.ok(cols.some((c) => c.name === 'owner_user_id'));
+  const row = database
+    .prepare('SELECT owner_user_id FROM discord_pushed_messages WHERE message_id = ?')
+    .get('m-1') as { owner_user_id: string | null };
+  assert.equal(row.owner_user_id, null, 'existing anchors are unvetted, not silently owned');
 });

--- a/src/__tests__/db-migrations.test.ts
+++ b/src/__tests__/db-migrations.test.ts
@@ -1,7 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import Database from 'better-sqlite3';
-import { ensureOwnerUserIdColumn, runMigrations } from '../core/db/migrations';
+import {
+  ensureDiscordPushedMessagesTable,
+  ensureOwnerUserIdColumn,
+  runMigrations,
+} from '../core/db/migrations';
 
 test('ensureOwnerUserIdColumn adds owner_user_id and is safe to rerun', () => {
   const database = new Database(':memory:');
@@ -109,4 +113,50 @@ test('runMigrations is idempotent on the new schema', () => {
     name: string;
   }>;
   assert.ok(cols.some((c) => c.name === 'provider'));
+});
+
+test('ensureDiscordPushedMessagesTable creates the anchor table and is safe to rerun', () => {
+  const database = new Database(':memory:');
+
+  ensureDiscordPushedMessagesTable(database);
+  ensureDiscordPushedMessagesTable(database);
+
+  const cols = database
+    .prepare("PRAGMA table_info('discord_pushed_messages')")
+    .all() as Array<{ name: string; pk: number; notnull: number }>;
+  const byName = new Map(cols.map((c) => [c.name, c]));
+
+  assert.deepEqual(
+    cols.map((c) => c.name).sort(),
+    ['agent_id', 'channel_id', 'created_at', 'message_id', 'session_id'],
+  );
+  assert.equal(byName.get('message_id')!.pk, 1, 'message_id is the primary key');
+  assert.equal(byName.get('session_id')!.notnull, 0, 'session_id is nullable');
+
+  // The retention purge filters on created_at; it must be indexed.
+  const indexes = database
+    .prepare("PRAGMA index_list('discord_pushed_messages')")
+    .all() as Array<{ name: string }>;
+  assert.ok(indexes.some((i) => i.name === 'idx_discord_pushed_messages_created_at'));
+});
+
+test('runMigrations creates discord_pushed_messages on a legacy database', () => {
+  const database = new Database(':memory:');
+  database.exec(`
+    CREATE TABLE agent_channels (
+      channel_id TEXT PRIMARY KEY,
+      guild_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      agent_name TEXT NOT NULL,
+      session_id TEXT,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch())
+    )
+  `);
+
+  runMigrations(database);
+
+  const table = database
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='discord_pushed_messages'")
+    .get() as { name?: string } | undefined;
+  assert.equal(table?.name, 'discord_pushed_messages');
 });

--- a/src/__tests__/discord-callout.test.ts
+++ b/src/__tests__/discord-callout.test.ts
@@ -228,3 +228,71 @@ test('a callout fallback carries the mention prefix', async () => {
     else process.env.DISCORD_MENTION_USER_ID = prev;
   }
 });
+
+// --- send() surfaces the posted message id (push-anchor support) ---
+
+/** A sendable channel whose `send()` returns a discord.js-shaped message. */
+function makeIdChannel(id: string, opts: { failEmbed?: boolean } = {}) {
+  const calls: unknown[] = [];
+  const channel = {
+    isSendable() {
+      return true;
+    },
+    async send(arg: unknown) {
+      calls.push(arg);
+      if (opts.failEmbed && typeof arg === 'object') {
+        throw new Error('Missing Permissions: Embed Links');
+      }
+      return { id };
+    },
+  };
+  return { channel, calls };
+}
+
+test('send returns the posted message id for a plain text message', async () => {
+  const { channel } = makeIdChannel('msg-plain');
+  const provider = makeProvider(channel);
+
+  const result = await provider.send(TARGET, { text: 'hello' });
+
+  assert.deepEqual(result, { messageId: 'msg-plain' });
+});
+
+test('send returns the posted message id for a callout embed', async () => {
+  const { channel } = makeIdChannel('msg-embed');
+  const provider = makeProvider(channel);
+
+  const result = await provider.send(TARGET, {
+    text: '> [!NOTE]\n> hi',
+    callout: { variant: 'NOTE', body: 'hi' },
+  } as OutgoingMessage);
+
+  assert.deepEqual(result, { messageId: 'msg-embed' });
+});
+
+test('send returns the message id of the plaintext fallback when the embed fails', async () => {
+  const { channel, calls } = makeIdChannel('msg-fallback', { failEmbed: true });
+  const provider = makeProvider(channel);
+
+  const result = await provider.send(TARGET, {
+    text: '> [!NOTE]\n> hi',
+    callout: { variant: 'NOTE', body: 'hi' },
+  } as OutgoingMessage);
+
+  assert.equal(calls.length, 2, 'embed attempt then plaintext fallback');
+  assert.deepEqual(result, { messageId: 'msg-fallback' });
+});
+
+test('send still surfaces a rate limit rather than a message id', async () => {
+  const provider = makeProvider({
+    isSendable: () => true,
+    async send() {
+      throw new RateLimitError(50);
+    },
+  });
+
+  await assert.rejects(
+    provider.send(TARGET, { text: 'hello' }),
+    (err: unknown) => err instanceof RateLimitError,
+  );
+});

--- a/src/__tests__/messageCreate.test.ts
+++ b/src/__tests__/messageCreate.test.ts
@@ -610,6 +610,7 @@ test('handleMessageCreate adopts a thread opened on an agent-pushed message', as
       channel_id: 'channel-1',
       agent_id: 'agent-push',
       session_id: 'session-push',
+      owner_user_id: 'user-1',
     },
   );
   const handler = createMessageCreateHandler(deps as any);
@@ -636,6 +637,87 @@ test('handleMessageCreate adopts with a null session when the push carried none'
       channel_id: 'channel-1',
       agent_id: 'agent-push',
       session_id: null,
+      owner_user_id: 'user-1',
+    },
+  );
+  const handler = createMessageCreateHandler(deps as any);
+
+  await handler(makeAdoptMessage() as any);
+
+  assert.equal(enqueued, 1);
+  assert.equal(registered.get('pushed-msg-1').session_id, null);
+});
+
+// --- the ownership gate on session inheritance ---
+//
+// Continuing a session means reading and extending its context, so an anchor
+// only hands `session_id` to the user it was addressed to. Everyone else either
+// gets a fresh session (unowned anchor) or nothing at all (wrong user).
+
+test('handleMessageCreate refuses a session handover to a user who is not the anchor owner', async () => {
+  let enqueued = 0;
+  const { deps, registered } = createAdoptDeps(
+    () => {
+      enqueued += 1;
+    },
+    {
+      message_id: 'pushed-msg-1',
+      channel_id: 'channel-1',
+      agent_id: 'agent-push',
+      session_id: 'session-push',
+      owner_user_id: 'owner-7',
+    },
+  );
+  const handler = createMessageCreateHandler(deps as any);
+
+  // `makeAdoptMessage` authors as `user-1`, a bystander here.
+  await handler(makeAdoptMessage() as any);
+
+  assert.equal(enqueued, 0, 'a bystander must not drive the pushed session');
+  assert.equal(registered.size, 0, 'and the thread stays claimable by its real owner');
+});
+
+test('handleMessageCreate adopts an unowned anchor into a fresh session', async () => {
+  let enqueued = 0;
+  const { deps, registered } = createAdoptDeps(
+    () => {
+      enqueued += 1;
+    },
+    {
+      message_id: 'pushed-msg-1',
+      channel_id: 'channel-1',
+      agent_id: 'agent-push',
+      session_id: 'session-push',
+      owner_user_id: null,
+    },
+  );
+  const handler = createMessageCreateHandler(deps as any);
+
+  await handler(makeAdoptMessage() as any);
+
+  assert.equal(enqueued, 1, 'the reply still reaches the agent');
+  const row = registered.get('pushed-msg-1');
+  assert.equal(row.agent_id, 'agent-push', 'routed to the pushing agent');
+  assert.equal(
+    row.session_id,
+    null,
+    'but with no vetted owner it must not inherit the pushed session',
+  );
+  assert.equal(row.owner_user_id, 'user-1');
+});
+
+test('handleMessageCreate treats a blank anchor owner as unvetted', async () => {
+  let enqueued = 0;
+  const { deps, registered } = createAdoptDeps(
+    () => {
+      enqueued += 1;
+    },
+    {
+      message_id: 'pushed-msg-1',
+      channel_id: 'channel-1',
+      agent_id: 'agent-push',
+      session_id: 'session-push',
+      owner_user_id: '   ',
     },
   );
   const handler = createMessageCreateHandler(deps as any);

--- a/src/__tests__/messageCreate.test.ts
+++ b/src/__tests__/messageCreate.test.ts
@@ -35,7 +35,9 @@ function createDeps(enqueue: (...args: any[]) => void) {
     threadDb: {
       get: () => ({ thread_id: 'thread-1' }) as any,
       register: () => undefined,
+      adopt: () => undefined,
     },
+    pushedMessagesDb: { get: () => undefined as any },
     getBotUserId: () => 'bot-1',
     enqueue,
     isVoiceMessage: () => true,
@@ -550,4 +552,192 @@ test('handleMessageCreate reports transcription failures and falls back to enque
   assert.equal(enqueued, 1, 'should enqueue original message as fallback on transcription error');
   assert.ok(reactions.includes('🎧'), 'should have 🎧 reaction even on failure');
   assert.ok(replies.some((r) => r.includes('Failed to transcribe this voice message')));
+});
+
+// --- adopt-on-miss: replying in a thread started on an agent push ---
+//
+// A thread created from a message carries that message's snowflake, so the
+// thread id is the lookup key into the push-anchor table. These cover the
+// happy path, the ownership binding, and every reason to refuse an adoption.
+
+/** A thread message whose thread id equals the anchored root message id. */
+function makeAdoptMessage(overrides: Record<string, unknown> = {}) {
+  return makeMessage({
+    channel: {
+      id: 'pushed-msg-1',
+      parentId: 'channel-1',
+      isThread: () => true,
+      sendTyping: async () => undefined,
+    },
+    ...overrides,
+  });
+}
+
+function createAdoptDeps(enqueue: (...args: any[]) => void, anchor: any) {
+  const deps = createDeps(enqueue);
+  const registered = new Map<string, any>();
+  deps.pushedMessagesDb.get = ((id: string) =>
+    anchor && id === anchor.message_id ? anchor : undefined) as any;
+  deps.threadDb.get = ((id: string) => registered.get(id)) as any;
+  deps.threadDb.adopt = ((
+    threadId: string,
+    channelId: string,
+    agentId: string,
+    ownerUserId: string | null,
+    sessionId: string | null,
+  ) => {
+    // Mirrors INSERT OR IGNORE: first writer wins.
+    if (registered.has(threadId)) return;
+    registered.set(threadId, {
+      thread_id: threadId,
+      channel_id: channelId,
+      agent_id: agentId,
+      owner_user_id: ownerUserId,
+      session_id: sessionId,
+    });
+  }) as any;
+  return { deps, registered };
+}
+
+test('handleMessageCreate adopts a thread opened on an agent-pushed message', async () => {
+  let enqueued = 0;
+  const { deps, registered } = createAdoptDeps(
+    () => {
+      enqueued += 1;
+    },
+    {
+      message_id: 'pushed-msg-1',
+      channel_id: 'channel-1',
+      agent_id: 'agent-push',
+      session_id: 'session-push',
+    },
+  );
+  const handler = createMessageCreateHandler(deps as any);
+
+  await handler(makeAdoptMessage() as any);
+
+  assert.equal(enqueued, 1, 'the reply should be routed, not dropped');
+  const row = registered.get('pushed-msg-1');
+  assert.ok(row, 'thread should now be registered');
+  assert.equal(row.channel_id, 'channel-1');
+  assert.equal(row.agent_id, 'agent-push', 'inherits the pushing agent');
+  assert.equal(row.session_id, 'session-push', 'inherits the pushed session');
+  assert.equal(row.owner_user_id, 'user-1', 'binds to the first replier');
+});
+
+test('handleMessageCreate adopts with a null session when the push carried none', async () => {
+  let enqueued = 0;
+  const { deps, registered } = createAdoptDeps(
+    () => {
+      enqueued += 1;
+    },
+    {
+      message_id: 'pushed-msg-1',
+      channel_id: 'channel-1',
+      agent_id: 'agent-push',
+      session_id: null,
+    },
+  );
+  const handler = createMessageCreateHandler(deps as any);
+
+  await handler(makeAdoptMessage() as any);
+
+  assert.equal(enqueued, 1);
+  assert.equal(registered.get('pushed-msg-1').session_id, null);
+});
+
+test('handleMessageCreate refuses to adopt when the thread parent is not the anchor channel', async () => {
+  let enqueued = 0;
+  const { deps, registered } = createAdoptDeps(
+    () => {
+      enqueued += 1;
+    },
+    {
+      message_id: 'pushed-msg-1',
+      channel_id: 'channel-1',
+      agent_id: 'agent-push',
+      session_id: 'session-push',
+    },
+  );
+  const handler = createMessageCreateHandler(deps as any);
+
+  await handler(
+    makeAdoptMessage({
+      channel: {
+        id: 'pushed-msg-1',
+        parentId: 'some-other-channel',
+        isThread: () => true,
+        sendTyping: async () => undefined,
+      },
+    }) as any,
+  );
+
+  assert.equal(enqueued, 0);
+  assert.equal(registered.size, 0);
+});
+
+test('handleMessageCreate leaves an already-registered thread binding untouched', async () => {
+  let enqueued = 0;
+  const { deps, registered } = createAdoptDeps(
+    () => {
+      enqueued += 1;
+    },
+    {
+      message_id: 'pushed-msg-1',
+      channel_id: 'channel-1',
+      agent_id: 'agent-push',
+      session_id: 'session-push',
+    },
+  );
+  // A first reply already adopted this thread and bound it to another user.
+  registered.set('pushed-msg-1', {
+    thread_id: 'pushed-msg-1',
+    channel_id: 'channel-1',
+    agent_id: 'agent-existing',
+    owner_user_id: 'owner-9',
+    session_id: 'session-existing',
+  });
+  const handler = createMessageCreateHandler(deps as any);
+
+  await handler(makeAdoptMessage() as any);
+
+  assert.equal(enqueued, 0, 'non-owner is still filtered out');
+  assert.equal(registered.get('pushed-msg-1').agent_id, 'agent-existing');
+  assert.equal(registered.get('pushed-msg-1').session_id, 'session-existing');
+});
+
+test('handleMessageCreate drops unregistered thread messages with no push anchor', async () => {
+  let enqueued = 0;
+  const { deps, registered } = createAdoptDeps(() => {
+    enqueued += 1;
+  }, null);
+  const handler = createMessageCreateHandler(deps as any);
+
+  await handler(makeAdoptMessage() as any);
+
+  assert.equal(enqueued, 0);
+  assert.equal(registered.size, 0);
+});
+
+test('handleMessageCreate does not enqueue when adopt fails to persist', async () => {
+  let enqueued = 0;
+  const { deps } = createAdoptDeps(
+    () => {
+      enqueued += 1;
+    },
+    {
+      message_id: 'pushed-msg-1',
+      channel_id: 'channel-1',
+      agent_id: 'agent-push',
+      session_id: 'session-push',
+    },
+  );
+  deps.threadDb.adopt = (() => {
+    throw new Error('db is locked');
+  }) as any;
+  const handler = createMessageCreateHandler(deps as any);
+
+  await handler(makeAdoptMessage() as any);
+
+  assert.equal(enqueued, 0, 'a failed adopt must not route the turn to a fresh session');
 });

--- a/src/__tests__/pushedMessagesDb.test.ts
+++ b/src/__tests__/pushedMessagesDb.test.ts
@@ -4,6 +4,7 @@ import { db } from '../core/db';
 import {
   PUSHED_MESSAGE_RETENTION_DAYS,
   pushedMessagesDb,
+  resolveAnchorOwner,
 } from '../providers/discord/pushedMessagesDb';
 
 let testId = 0;
@@ -41,7 +42,7 @@ test('pushedMessagesDb.record and get round-trip', () => {
   const msgId = track(uid('msg'));
   const chId = uid('ch');
 
-  pushedMessagesDb.record(msgId, chId, 'agent-1', 'session-1');
+  pushedMessagesDb.record(msgId, chId, 'agent-1', 'session-1', 'user-1');
   const row = pushedMessagesDb.get(msgId);
 
   assert.ok(row);
@@ -49,13 +50,27 @@ test('pushedMessagesDb.record and get round-trip', () => {
   assert.equal(row.channel_id, chId);
   assert.equal(row.agent_id, 'agent-1');
   assert.equal(row.session_id, 'session-1');
+  assert.equal(row.owner_user_id, 'user-1');
   assert.equal(typeof row.created_at, 'number');
 });
 
-test('pushedMessagesDb.record defaults session_id to null', () => {
+test('pushedMessagesDb.record defaults session_id and owner_user_id to null', () => {
   const msgId = track(uid('msg'));
   pushedMessagesDb.record(msgId, uid('ch'), 'agent-1');
-  assert.equal(pushedMessagesDb.get(msgId)!.session_id, null);
+  const row = pushedMessagesDb.get(msgId)!;
+  assert.equal(row.session_id, null);
+  assert.equal(row.owner_user_id, null, 'no owner unless one was recorded');
+});
+
+test('pushedMessagesDb.record re-recording replaces the owner too', () => {
+  const msgId = track(uid('msg'));
+  pushedMessagesDb.record(msgId, 'ch-a', 'agent-a', 'session-a', 'user-a');
+  pushedMessagesDb.record(msgId, 'ch-a', 'agent-a', 'session-b', null);
+  assert.equal(
+    pushedMessagesDb.get(msgId)!.owner_user_id,
+    null,
+    're-record must not leave a stale owner behind',
+  );
 });
 
 test('pushedMessagesDb.record re-recording the same message id overwrites the binding', () => {
@@ -110,4 +125,24 @@ test('pushedMessagesDb.removeByChannel clears every anchor for a channel', () =>
   assert.equal(pushedMessagesDb.get(a), undefined);
   assert.equal(pushedMessagesDb.get(b), undefined);
   assert.ok(pushedMessagesDb.get(other), 'other channels are untouched');
+});
+
+// --- who may inherit a push's session ---
+
+test('resolveAnchorOwner prefers the caller-supplied user over the mention user', () => {
+  assert.equal(resolveAnchorOwner('u-1', 'mention-user'), 'u-1');
+});
+
+test('resolveAnchorOwner falls back to the configured mention user', () => {
+  assert.equal(resolveAnchorOwner(null, 'mention-user'), 'mention-user');
+  assert.equal(resolveAnchorOwner(undefined, 'mention-user'), 'mention-user');
+});
+
+test('resolveAnchorOwner collapses blank ids to null rather than a bogus owner', () => {
+  // `DISCORD_MENTION_USER_ID` is '' when unset; an empty id must never read as
+  // an owner, or every replier would match it.
+  assert.equal(resolveAnchorOwner(null, ''), null);
+  assert.equal(resolveAnchorOwner('  ', '  '), null);
+  assert.equal(resolveAnchorOwner('  ', 'mention-user'), 'mention-user');
+  assert.equal(resolveAnchorOwner(undefined, undefined), null);
 });

--- a/src/__tests__/pushedMessagesDb.test.ts
+++ b/src/__tests__/pushedMessagesDb.test.ts
@@ -1,0 +1,113 @@
+import test, { afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { db } from '../core/db';
+import {
+  PUSHED_MESSAGE_RETENTION_DAYS,
+  pushedMessagesDb,
+} from '../providers/discord/pushedMessagesDb';
+
+let testId = 0;
+function uid(prefix: string) {
+  testId++;
+  return `${prefix}-test-${testId}-${Date.now()}`;
+}
+
+const created: string[] = [];
+function track(id: string) {
+  created.push(id);
+  return id;
+}
+
+afterEach(() => {
+  for (const id of created) {
+    try {
+      db.prepare('DELETE FROM discord_pushed_messages WHERE message_id = ?').run(id);
+    } catch {
+      /* ignore */
+    }
+  }
+  created.length = 0;
+});
+
+/** Backdate a row so retention can be exercised without waiting 30 days. */
+function ageRow(messageId: string, days: number) {
+  db.prepare('UPDATE discord_pushed_messages SET created_at = ? WHERE message_id = ?').run(
+    Math.floor(Date.now() / 1000) - days * 24 * 60 * 60,
+    messageId,
+  );
+}
+
+test('pushedMessagesDb.record and get round-trip', () => {
+  const msgId = track(uid('msg'));
+  const chId = uid('ch');
+
+  pushedMessagesDb.record(msgId, chId, 'agent-1', 'session-1');
+  const row = pushedMessagesDb.get(msgId);
+
+  assert.ok(row);
+  assert.equal(row.message_id, msgId);
+  assert.equal(row.channel_id, chId);
+  assert.equal(row.agent_id, 'agent-1');
+  assert.equal(row.session_id, 'session-1');
+  assert.equal(typeof row.created_at, 'number');
+});
+
+test('pushedMessagesDb.record defaults session_id to null', () => {
+  const msgId = track(uid('msg'));
+  pushedMessagesDb.record(msgId, uid('ch'), 'agent-1');
+  assert.equal(pushedMessagesDb.get(msgId)!.session_id, null);
+});
+
+test('pushedMessagesDb.record re-recording the same message id overwrites the binding', () => {
+  const msgId = track(uid('msg'));
+  pushedMessagesDb.record(msgId, 'ch-a', 'agent-a', 'session-a');
+  pushedMessagesDb.record(msgId, 'ch-b', 'agent-b', 'session-b');
+
+  const row = pushedMessagesDb.get(msgId)!;
+  assert.equal(row.agent_id, 'agent-b');
+  assert.equal(row.session_id, 'session-b');
+});
+
+test('pushedMessagesDb.get returns undefined for an unknown message', () => {
+  assert.equal(pushedMessagesDb.get('no-such-message'), undefined);
+});
+
+test('pushedMessagesDb.purgeOlderThan drops aged rows and keeps fresh ones', () => {
+  const oldId = track(uid('msg-old'));
+  const freshId = track(uid('msg-fresh'));
+  pushedMessagesDb.record(oldId, uid('ch'), 'agent-1', 'session-1');
+  pushedMessagesDb.record(freshId, uid('ch'), 'agent-1', 'session-1');
+  ageRow(oldId, PUSHED_MESSAGE_RETENTION_DAYS + 1);
+
+  const removed = pushedMessagesDb.purgeOlderThan(PUSHED_MESSAGE_RETENTION_DAYS);
+
+  assert.ok(removed >= 1);
+  assert.equal(pushedMessagesDb.get(oldId), undefined);
+  assert.ok(pushedMessagesDb.get(freshId), 'a fresh anchor must survive the purge');
+});
+
+test('pushedMessagesDb.purgeOlderThan keeps a row exactly at the retention edge', () => {
+  const edgeId = track(uid('msg-edge'));
+  pushedMessagesDb.record(edgeId, uid('ch'), 'agent-1', 'session-1');
+  ageRow(edgeId, PUSHED_MESSAGE_RETENTION_DAYS - 1);
+
+  pushedMessagesDb.purgeOlderThan(PUSHED_MESSAGE_RETENTION_DAYS);
+
+  assert.ok(pushedMessagesDb.get(edgeId));
+});
+
+test('pushedMessagesDb.removeByChannel clears every anchor for a channel', () => {
+  const chId = uid('ch');
+  const a = track(uid('msg'));
+  const b = track(uid('msg'));
+  const other = track(uid('msg'));
+  pushedMessagesDb.record(a, chId, 'agent-1', 'session-1');
+  pushedMessagesDb.record(b, chId, 'agent-1', 'session-1');
+  pushedMessagesDb.record(other, uid('ch-other'), 'agent-1', 'session-1');
+
+  pushedMessagesDb.removeByChannel(chId);
+
+  assert.equal(pushedMessagesDb.get(a), undefined);
+  assert.equal(pushedMessagesDb.get(b), undefined);
+  assert.ok(pushedMessagesDb.get(other), 'other channels are untouched');
+});

--- a/src/__tests__/sendRetry.test.ts
+++ b/src/__tests__/sendRetry.test.ts
@@ -57,3 +57,18 @@ test('sendWithRetry rethrows a non-RateLimitError immediately without retrying',
   );
   assert.equal(calls, 1);
 });
+
+test('sendWithRetry passes the send result through to the caller', async () => {
+  const result = await sendWithRetry(async () => ({ messageId: 'm-1' }), MSG);
+  assert.deepEqual(result, { messageId: 'm-1' });
+});
+
+test('sendWithRetry passes through the result of the attempt that finally succeeded', async () => {
+  let calls = 0;
+  const result = await sendWithRetry(async () => {
+    calls++;
+    if (calls === 1) throw new RateLimitError(5);
+    return { messageId: `m-${calls}` };
+  }, MSG);
+  assert.deepEqual(result, { messageId: 'm-2' });
+});

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -515,3 +515,167 @@ test('parseBody rejects invalid JSON', async () => {
   req.destroy = () => {};
   await assert.rejects(mod.parseBody!(req), /Invalid JSON/);
 });
+
+// --- push anchors: recording pushed messages so replies can find the session ---
+
+interface AnchorRecord {
+  messageId: string;
+  channelId: string;
+  agentId: string;
+  sessionId?: string | null;
+}
+
+/**
+ * A provider that reports message ids from `send` (like Discord) and captures
+ * what the API asks it to record.
+ */
+function makeAnchoringProvider(opts: {
+  anchors: AnchorRecord[];
+  sentMessages?: string[];
+  recordThrows?: Error;
+}): BridgeProvider {
+  const sent = opts.sentMessages ?? [];
+  let counter = 0;
+  return {
+    name: 'discord',
+    isReady: () => true,
+    async start() {},
+    async stop() {},
+    resolveConversation: () => null,
+    send: async (_target, msg) => {
+      sent.push(msg.text);
+      counter += 1;
+      return { messageId: `msg-${counter}` };
+    },
+    recordPushedMessage: (record) => {
+      if (opts.recordThrows) throw opts.recordThrows;
+      opts.anchors.push(record);
+    },
+    findOrCreateAgentChannel: async (agentId) => ({
+      channelId: 'ch-1',
+      agentId,
+      agentName: 'Test',
+    }),
+  };
+}
+
+test('POST /api/send records a push anchor per posted message with the given sessionId', async () => {
+  const anchors: AnchorRecord[] = [];
+  const server = await startTestServer(
+    makeDeps({
+      providers: new Map([['discord', makeAnchoringProvider({ anchors })]]),
+      // Two parts: a human may reply to either, so both must be anchored.
+      splitMessage: () => ['part-0', 'part-1'],
+    }),
+  );
+  try {
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'hello', sessionId: 'session-42' },
+    });
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body.messageIds, ['msg-1', 'msg-2']);
+    assert.deepEqual(anchors, [
+      { messageId: 'msg-1', channelId: 'ch-1', agentId: 'a-1', sessionId: 'session-42' },
+      { messageId: 'msg-2', channelId: 'ch-1', agentId: 'a-1', sessionId: 'session-42' },
+    ]);
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /api/send records an anchor with a null session when sessionId is omitted', async () => {
+  const anchors: AnchorRecord[] = [];
+  const server = await startTestServer(
+    makeDeps({ providers: new Map([['discord', makeAnchoringProvider({ anchors })]]) }),
+  );
+  try {
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'hello' },
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(anchors.length, 1);
+    assert.equal(anchors[0].sessionId, null);
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /api/send treats a blank sessionId as absent', async () => {
+  const anchors: AnchorRecord[] = [];
+  const server = await startTestServer(
+    makeDeps({ providers: new Map([['discord', makeAnchoringProvider({ anchors })]]) }),
+  );
+  try {
+    await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'hello', sessionId: '   ' },
+    });
+    assert.equal(anchors[0].sessionId, null);
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /api/send returns 400 for a non-string sessionId', async () => {
+  const server = await startTestServer(makeDeps());
+  try {
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'hello', sessionId: 42 },
+    });
+    assert.equal(res.status, 400);
+    assert.match(res.body.error, /sessionId/);
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /api/send still succeeds when the provider cannot anchor messages', async () => {
+  // The stock mock provider has no recordPushedMessage and returns no ids.
+  const server = await startTestServer(makeDeps());
+  try {
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'hello', sessionId: 'session-42' },
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body.messageIds, []);
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /api/send still returns 200 when recording the anchor throws', async () => {
+  const anchors: AnchorRecord[] = [];
+  const server = await startTestServer(
+    makeDeps({
+      providers: new Map([
+        [
+          'discord',
+          makeAnchoringProvider({ anchors, recordThrows: new Error('db is locked') }),
+        ],
+      ]),
+    }),
+  );
+  try {
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'hello', sessionId: 'session-42' },
+    });
+    // The message was delivered; bookkeeping failure must not mask that.
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+  } finally {
+    server.close();
+  }
+});

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -523,6 +523,7 @@ interface AnchorRecord {
   channelId: string;
   agentId: string;
   sessionId?: string | null;
+  ownerUserId?: string | null;
 }
 
 /**
@@ -572,14 +573,26 @@ test('POST /api/send records a push anchor per posted message with the given ses
     const res = await request(server, {
       method: 'POST',
       path: '/api/send',
-      body: { agentId: 'a-1', message: 'hello', sessionId: 'session-42' },
+      body: { agentId: 'a-1', message: 'hello', sessionId: 'session-42', userId: 'u-9' },
     });
 
     assert.equal(res.status, 200);
     assert.deepEqual(res.body.messageIds, ['msg-1', 'msg-2']);
     assert.deepEqual(anchors, [
-      { messageId: 'msg-1', channelId: 'ch-1', agentId: 'a-1', sessionId: 'session-42' },
-      { messageId: 'msg-2', channelId: 'ch-1', agentId: 'a-1', sessionId: 'session-42' },
+      {
+        messageId: 'msg-1',
+        channelId: 'ch-1',
+        agentId: 'a-1',
+        sessionId: 'session-42',
+        ownerUserId: 'u-9',
+      },
+      {
+        messageId: 'msg-2',
+        channelId: 'ch-1',
+        agentId: 'a-1',
+        sessionId: 'session-42',
+        ownerUserId: 'u-9',
+      },
     ]);
   } finally {
     server.close();
@@ -618,6 +631,48 @@ test('POST /api/send treats a blank sessionId as absent', async () => {
       body: { agentId: 'a-1', message: 'hello', sessionId: '   ' },
     });
     assert.equal(anchors[0].sessionId, null);
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /api/send records a null owner when userId is omitted or blank', async () => {
+  const anchors: AnchorRecord[] = [];
+  const server = await startTestServer(
+    makeDeps({ providers: new Map([['discord', makeAnchoringProvider({ anchors })]]) }),
+  );
+  try {
+    await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'hello', sessionId: 'session-42' },
+    });
+    await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'hello', sessionId: 'session-42', userId: '  ' },
+    });
+    // Null, never a bogus owner — the provider decides the fallback, and an
+    // unowned anchor hands out no session.
+    assert.deepEqual(
+      anchors.map((a) => a.ownerUserId),
+      [null, null],
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /api/send returns 400 for a non-string userId', async () => {
+  const server = await startTestServer(makeDeps());
+  try {
+    const res = await request(server, {
+      method: 'POST',
+      path: '/api/send',
+      body: { agentId: 'a-1', message: 'hello', userId: 42 },
+    });
+    assert.equal(res.status, 400);
+    assert.match(res.body.error, /userId/);
   } finally {
     server.close();
   }

--- a/src/cli/lib.ts
+++ b/src/cli/lib.ts
@@ -9,11 +9,18 @@ export interface SendApiPayload {
   message: string;
   mention?: boolean;
   provider?: string;
+  /**
+   * Maestro session the push belongs to. Recorded against the posted messages so
+   * a reply thread started on one of them continues this session.
+   */
+  sessionId?: string;
 }
 
 export interface SendApiResult {
   success: boolean;
   channelId?: string;
+  /** Platform message ids of the posted messages (providers that report them). */
+  messageIds?: string[];
   error?: string;
 }
 

--- a/src/cli/lib.ts
+++ b/src/cli/lib.ts
@@ -14,6 +14,12 @@ export interface SendApiPayload {
    * a reply thread started on one of them continues this session.
    */
   sessionId?: string;
+  /**
+   * Platform user id allowed to continue `sessionId` from a reply thread on the
+   * push. Omitted means the provider's configured mention user, and failing
+   * that no vetted owner — a reply thread then starts a fresh session.
+   */
+  userId?: string;
 }
 
 export interface SendApiResult {

--- a/src/cli/verbs/send.ts
+++ b/src/cli/verbs/send.ts
@@ -1,7 +1,7 @@
 import { parseArgs } from 'node:util';
 import { DEFAULT_PORT, fail, ok, parsePort, postToSendApi } from '../lib';
 
-export const sendUsage = `Usage: maestro-relay send --agent <id> --message <text> [--provider <name>] [--mention] [--port <number>]
+export const sendUsage = `Usage: maestro-relay send --agent <id> --message <text> [--provider <name>] [--mention] [--session <id>] [--port <number>]
 
 Send a message to an agent's bridge channel (auto-creates channel if needed).
 
@@ -10,6 +10,9 @@ Options:
   -m, --message <text>  Message text to send (required)
       --provider <name> Provider/module name (default: discord)
       --mention         Mention the user set in DISCORD_MENTION_USER_ID
+  -s, --session <id>    Maestro session this push belongs to. A reply thread
+                        started on the pushed message continues this session
+                        instead of opening a new one (Discord).
   -p, --port <number>   API port (default: ${DEFAULT_PORT})
   -h, --help            Show this help`;
 
@@ -23,6 +26,7 @@ export async function runSend(argv: string[]): Promise<void> {
         message: { type: 'string', short: 'm' },
         provider: { type: 'string' },
         mention: { type: 'boolean', default: false },
+        session: { type: 'string', short: 's' },
         port: { type: 'string', short: 'p' },
         help: { type: 'boolean', short: 'h', default: false },
       },
@@ -60,6 +64,7 @@ export async function runSend(argv: string[]): Promise<void> {
         message,
         provider: parsed.values.provider,
         mention: parsed.values.mention,
+        sessionId: parsed.values.session,
       },
       port,
     );

--- a/src/cli/verbs/send.ts
+++ b/src/cli/verbs/send.ts
@@ -1,7 +1,7 @@
 import { parseArgs } from 'node:util';
 import { DEFAULT_PORT, fail, ok, parsePort, postToSendApi } from '../lib';
 
-export const sendUsage = `Usage: maestro-relay send --agent <id> --message <text> [--provider <name>] [--mention] [--session <id>] [--port <number>]
+export const sendUsage = `Usage: maestro-relay send --agent <id> --message <text> [--provider <name>] [--mention] [--session <id>] [--user <id>] [--port <number>]
 
 Send a message to an agent's bridge channel (auto-creates channel if needed).
 
@@ -13,6 +13,9 @@ Options:
   -s, --session <id>    Maestro session this push belongs to. A reply thread
                         started on the pushed message continues this session
                         instead of opening a new one (Discord).
+  -u, --user <id>       Platform user id allowed to continue --session from a
+                        reply thread. Defaults to DISCORD_MENTION_USER_ID; with
+                        neither, a reply thread starts a fresh session.
   -p, --port <number>   API port (default: ${DEFAULT_PORT})
   -h, --help            Show this help`;
 
@@ -27,6 +30,7 @@ export async function runSend(argv: string[]): Promise<void> {
         provider: { type: 'string' },
         mention: { type: 'boolean', default: false },
         session: { type: 'string', short: 's' },
+        user: { type: 'string', short: 'u' },
         port: { type: 'string', short: 'p' },
         help: { type: 'boolean', short: 'h', default: false },
       },
@@ -65,6 +69,7 @@ export async function runSend(argv: string[]): Promise<void> {
         provider: parsed.values.provider,
         mention: parsed.values.mention,
         sessionId: parsed.values.session,
+        userId: parsed.values.user,
       },
       port,
     );

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -14,6 +14,13 @@ export interface SendRequest {
   mention?: boolean;
   /** Optional provider name; defaults to 'discord' for back-compat. */
   provider?: string;
+  /**
+   * Optional maestro session the push belongs to. When present (and the
+   * provider supports anchoring), the posted messages are recorded so a reply
+   * thread started on one of them continues *this* session instead of opening a
+   * fresh one.
+   */
+  sessionId?: string;
 }
 
 export type ApiDeps = {
@@ -100,6 +107,12 @@ export function createServerHandler(deps: ApiDeps) {
       return;
     }
 
+    if (body.sessionId !== undefined && typeof body.sessionId !== 'string') {
+      sendJson(res, 400, { success: false, error: 'sessionId must be a string when provided' });
+      return;
+    }
+    const sessionId = body.sessionId?.trim() || null;
+
     const providerName = body.provider ?? 'discord';
     const provider = deps.providers.get(providerName);
     if (!provider) {
@@ -139,9 +152,15 @@ export function createServerHandler(deps: ApiDeps) {
     // `renderTables` to pushed text is an intentional behavior change (decision #6).
     const messages = toOutgoing(body.message, { split, renderTables, mention: !!body.mention });
 
+    // Message ids of this push, so a reply-thread on any of them can be routed
+    // back into the agent session that produced it. Every part is recorded, not
+    // just the first: a long push splits into several messages and the human
+    // may well answer the last one.
+    const messageIds: string[] = [];
     try {
       for (const m of messages) {
-        await sendWithRetry((x) => provider.send(target, x), m);
+        const result = await sendWithRetry((x) => provider.send(target, x), m);
+        if (result?.messageId) messageIds.push(result.messageId);
       }
     } catch (err) {
       if (err instanceof RateLimitError) {
@@ -164,7 +183,28 @@ export function createServerHandler(deps: ApiDeps) {
       return;
     }
 
-    sendJson(res, 200, { success: true, channelId: info.channelId });
+    // Bookkeeping only — the push already succeeded, so a failure here must not
+    // turn a delivered message into a 500 for the caller.
+    if (provider.recordPushedMessage) {
+      for (const messageId of messageIds) {
+        try {
+          provider.recordPushedMessage({
+            messageId,
+            channelId: info.channelId,
+            agentId: info.agentId,
+            sessionId,
+          });
+        } catch (err) {
+          await log.error('api/recordPushedMessage', (err as Error).message);
+        }
+      }
+    }
+
+    sendJson(res, 200, {
+      success: true,
+      channelId: info.channelId,
+      messageIds,
+    });
   }
 
   return function handler(req: http.IncomingMessage, res: http.ServerResponse) {

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -21,6 +21,13 @@ export interface SendRequest {
    * fresh one.
    */
   sessionId?: string;
+  /**
+   * Optional platform user id allowed to continue `sessionId` by replying in a
+   * thread on this push. Without it the provider falls back to its configured
+   * mention user, and failing that a reply thread starts a *fresh* session —
+   * an anchor never hands an existing session to an unvetted replier.
+   */
+  userId?: string;
 }
 
 export type ApiDeps = {
@@ -113,6 +120,12 @@ export function createServerHandler(deps: ApiDeps) {
     }
     const sessionId = body.sessionId?.trim() || null;
 
+    if (body.userId !== undefined && typeof body.userId !== 'string') {
+      sendJson(res, 400, { success: false, error: 'userId must be a string when provided' });
+      return;
+    }
+    const userId = body.userId?.trim() || null;
+
     const providerName = body.provider ?? 'discord';
     const provider = deps.providers.get(providerName);
     if (!provider) {
@@ -193,6 +206,7 @@ export function createServerHandler(deps: ApiDeps) {
             channelId: info.channelId,
             agentId: info.agentId,
             sessionId,
+            ownerUserId: userId,
           });
         } catch (err) {
           await log.error('api/recordPushedMessage', (err as Error).message);

--- a/src/core/db/migrations.ts
+++ b/src/core/db/migrations.ts
@@ -19,6 +19,9 @@ import type Database from 'better-sqlite3';
  *     per-client low-water mark that reconnect-gap reconciliation replays from
  * 11. Add `max_lifetime_turns` / `lifetime_turn_count` to `rooms` — the hard
  *     loop backstop that (unlike the burst counter) only resets on `/room reset`
+ * 12. Create `discord_pushed_messages` (message_id → channel/agent/session): the
+ *     anchor registry that lets a thread started on an agent-pushed message
+ *     inherit that message's session
  */
 export function runMigrations(db: Database.Database): void {
   ensureReadOnlyColumn(db);
@@ -33,6 +36,36 @@ export function runMigrations(db: Database.Database): void {
   ensureRoomLifetimeTurnColumns(db);
   ensureRoomBotsRegistryTable(db);
   ensureRoomBotCursorsTable(db);
+  ensureDiscordPushedMessagesTable(db);
+}
+
+/**
+ * Anchor registry for agent-initiated pushes (migration 12).
+ *
+ * `/api/send` records every message it posts here, keyed on the platform
+ * message id. Discord gives a thread created *from* a message the same
+ * snowflake as that message, so when an inbound thread message arrives for a
+ * thread the bridge has never registered, its channel id can be looked up here
+ * directly: a hit means the human replied to an agent push, and the thread is
+ * adopted with the pushed message's agent and session (see
+ * `providers/discord/messageCreate.ts`). Rows are purged after 30 days —
+ * `providers/discord/pushedMessagesDb.ts`. Stores ids only, never content.
+ */
+export function ensureDiscordPushedMessagesTable(database: Database.Database): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS discord_pushed_messages (
+      message_id  TEXT PRIMARY KEY,
+      channel_id  TEXT NOT NULL,
+      agent_id    TEXT NOT NULL,
+      session_id  TEXT,
+      created_at  INTEGER NOT NULL DEFAULT (unixepoch())
+    )
+  `);
+  // The retention purge scans by age; keep it from degrading into a table scan.
+  database.exec(`
+    CREATE INDEX IF NOT EXISTS idx_discord_pushed_messages_created_at
+      ON discord_pushed_messages (created_at)
+  `);
 }
 
 /**

--- a/src/core/db/migrations.ts
+++ b/src/core/db/migrations.ts
@@ -19,9 +19,9 @@ import type Database from 'better-sqlite3';
  *     per-client low-water mark that reconnect-gap reconciliation replays from
  * 11. Add `max_lifetime_turns` / `lifetime_turn_count` to `rooms` — the hard
  *     loop backstop that (unlike the burst counter) only resets on `/room reset`
- * 12. Create `discord_pushed_messages` (message_id → channel/agent/session): the
- *     anchor registry that lets a thread started on an agent-pushed message
- *     inherit that message's session
+ * 12. Create `discord_pushed_messages` (message_id → channel/agent/session plus
+ *     the `owner_user_id` allowed to inherit it): the anchor registry that lets
+ *     a thread started on an agent-pushed message inherit that message's session
  */
 export function runMigrations(db: Database.Database): void {
   ensureReadOnlyColumn(db);
@@ -54,13 +54,22 @@ export function runMigrations(db: Database.Database): void {
 export function ensureDiscordPushedMessagesTable(database: Database.Database): void {
   database.exec(`
     CREATE TABLE IF NOT EXISTS discord_pushed_messages (
-      message_id  TEXT PRIMARY KEY,
-      channel_id  TEXT NOT NULL,
-      agent_id    TEXT NOT NULL,
-      session_id  TEXT,
-      created_at  INTEGER NOT NULL DEFAULT (unixepoch())
+      message_id    TEXT PRIMARY KEY,
+      channel_id    TEXT NOT NULL,
+      agent_id      TEXT NOT NULL,
+      session_id    TEXT,
+      owner_user_id TEXT,
+      created_at    INTEGER NOT NULL DEFAULT (unixepoch())
     )
   `);
+  // Additive for databases created before the ownership gate existed. A row
+  // without an owner is treated as "nobody vetted" at adoption time, so
+  // backfilling is neither possible nor needed.
+  try {
+    database.exec('ALTER TABLE discord_pushed_messages ADD COLUMN owner_user_id TEXT');
+  } catch (error) {
+    if (!(error instanceof Error) || !/duplicate column name/i.test(error.message)) throw error;
+  }
   // The retention purge scans by age; keep it from degrading into a table scan.
   database.exec(`
     CREATE INDEX IF NOT EXISTS idx_discord_pushed_messages_created_at

--- a/src/core/sendRetry.ts
+++ b/src/core/sendRetry.ts
@@ -29,19 +29,22 @@ export interface SendWithRetryOptions {
  * caller for more than a few seconds. On any non-`RateLimitError` it rethrows
  * immediately. If every attempt is exhausted it rethrows the last error, so a
  * caller can translate a final `RateLimitError` into an HTTP 429.
+ *
+ * Whatever `send` resolves to is passed straight back, so a caller that needs
+ * the provider's `SendResult` (e.g. the push API recording message ids) does not
+ * have to bypass the retry wrapper to get it.
  */
-export async function sendWithRetry(
-  send: (msg: OutgoingMessage) => Promise<void>,
+export async function sendWithRetry<T>(
+  send: (msg: OutgoingMessage) => Promise<T>,
   msg: OutgoingMessage,
   opts: SendWithRetryOptions = {},
-): Promise<void> {
+): Promise<T> {
   const retries = opts.retries ?? 3;
   let lastError: Error | undefined;
 
   for (let attempt = 0; attempt < retries; attempt++) {
     try {
-      await send(msg);
-      return;
+      return await send(msg);
     } catch (err) {
       if (err instanceof RateLimitError) {
         lastError = err;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -191,6 +191,13 @@ export interface PushedMessage {
   agentId: string;
   /** The maestro session the push belongs to; null when the caller sent none. */
   sessionId?: string | null;
+  /**
+   * Platform user id authorized to continue `sessionId` from a reply thread on
+   * this message. Null means "nobody vetted": the provider must then route such
+   * a reply into a *fresh* session rather than handing over this one, so an
+   * anchor can never leak an existing session's context to a bystander.
+   */
+  ownerUserId?: string | null;
 }
 
 export interface AgentChannelInfo {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -174,6 +174,25 @@ export interface ReactionHandle {
   remove(): Promise<void>;
 }
 
+/** What a provider can report back about a message it just posted. */
+export interface SendResult {
+  /** Platform message id of the posted message, when the provider exposes one. */
+  messageId?: string;
+}
+
+/**
+ * A message the bridge pushed into a channel on an agent's behalf, recorded so
+ * an inbound reply anchored on it can be routed back to the originating agent
+ * session instead of being dropped.
+ */
+export interface PushedMessage {
+  messageId: string;
+  channelId: string;
+  agentId: string;
+  /** The maestro session the push belongs to; null when the caller sent none. */
+  sessionId?: string | null;
+}
+
 export interface AgentChannelInfo {
   channelId: string;
   agentId: string;
@@ -195,8 +214,16 @@ export interface BridgeProvider {
    */
   resolveConversation(message: IncomingMessage): ConversationRecord | null;
 
-  /** Send a message into a conversation. */
-  send(target: ChannelTarget, msg: OutgoingMessage): Promise<void>;
+  /**
+   * Send a message into a conversation.
+   *
+   * Returning a `SendResult` is optional: providers that can surface the id of
+   * the message they just posted do so (Discord), and callers that need an
+   * anchor — e.g. the push API, which records the pushed message so a later
+   * reply-thread on it can inherit the agent session — use it. Providers with
+   * nothing useful to report keep returning `void`.
+   */
+  send(target: ChannelTarget, msg: OutgoingMessage): Promise<SendResult | void>;
 
   /**
    * Optional: send a message under a distinct per-message identity (multi-agent
@@ -214,6 +241,15 @@ export interface BridgeProvider {
    * Used by the HTTP API for agent-initiated messages.
    */
   findOrCreateAgentChannel(agentId: string): Promise<AgentChannelInfo>;
+
+  /**
+   * Optional: remember that `record.messageId` was pushed into `record.channelId`
+   * on behalf of `record.agentId` / `record.sessionId`. The push API calls this
+   * after a successful `/api/send` so the provider can later adopt a reply
+   * anchored on that message into the right session. Providers that cannot
+   * anchor replies simply omit it.
+   */
+  recordPushedMessage?(record: PushedMessage): void;
 
   /** Optional: react to a message (used as a "queued" indicator). */
   react?(target: MessageTarget, emoji: string): Promise<ReactionHandle>;

--- a/src/providers/discord/adapter.ts
+++ b/src/providers/discord/adapter.ts
@@ -34,7 +34,11 @@ import { clampTitle, clampDescription } from './embed';
 import { discordConfig } from './config';
 import { channelDb } from './channelsDb';
 import { threadDb } from './threadsDb';
-import { pushedMessagesDb, PUSHED_MESSAGE_RETENTION_DAYS } from './pushedMessagesDb';
+import {
+  pushedMessagesDb,
+  resolveAnchorOwner,
+  PUSHED_MESSAGE_RETENTION_DAYS,
+} from './pushedMessagesDb';
 import { createMessageCreateHandler } from './messageCreate';
 import { createRoomMessageHandler } from './roomMessageCreate';
 import { RoomGatewayManager } from './roomGateways';
@@ -389,6 +393,11 @@ export class DiscordProvider implements BridgeProvider {
         record.channelId,
         record.agentId,
         record.sessionId ?? null,
+        // Falls back to the configured mention user: they are who this bot's
+        // pushes are addressed to, so they are the one person who may pick the
+        // session back up. No caller-supplied user and no configured mention
+        // user means no vetted owner, and a reply thread then starts fresh.
+        resolveAnchorOwner(record.ownerUserId, discordConfig.mentionUserId),
       );
     } catch (err) {
       void logger.error(

--- a/src/providers/discord/adapter.ts
+++ b/src/providers/discord/adapter.ts
@@ -17,10 +17,13 @@ import type {
   ConversationRecord,
   IncomingMessage,
   KernelContext,
+  KernelLogger,
   MessageTarget,
   OutgoingMessage,
   PersonaIdentity,
+  PushedMessage,
   ReactionHandle,
+  SendResult,
 } from '../../core/types';
 import { maestro } from '../../core/maestro';
 import { logger } from '../../core/logger';
@@ -31,6 +34,7 @@ import { clampTitle, clampDescription } from './embed';
 import { discordConfig } from './config';
 import { channelDb } from './channelsDb';
 import { threadDb } from './threadsDb';
+import { pushedMessagesDb, PUSHED_MESSAGE_RETENTION_DAYS } from './pushedMessagesDb';
 import { createMessageCreateHandler } from './messageCreate';
 import { createRoomMessageHandler } from './roomMessageCreate';
 import { RoomGatewayManager } from './roomGateways';
@@ -74,6 +78,8 @@ export class DiscordProvider implements BridgeProvider {
    */
   private handleRoomMessage: ((message: import('discord.js').Message) => void | Promise<void>) | null =
     null;
+  /** Daily retention sweep over the push-anchor table (see `startPushAnchorPurge`). */
+  private pushPurgeTimer: NodeJS.Timeout | null = null;
   private pendingChannels = new Map<string, Promise<AgentChannelInfo>>();
   private pendingCategory: Promise<CategoryChannel> | null = null;
 
@@ -158,9 +164,12 @@ export class DiscordProvider implements BridgeProvider {
       }
     });
 
+    this.startPushAnchorPurge(ctx.logger);
+
     const handleMessageCreate = createMessageCreateHandler({
       channelDb,
       threadDb,
+      pushedMessagesDb,
       getBotUserId: (message) => message.client.user?.id,
       enqueue: ctx.enqueue,
       isVoiceMessage,
@@ -231,7 +240,36 @@ export class DiscordProvider implements BridgeProvider {
     }
   }
 
+  /**
+   * Retention for push anchors: purge on startup, then once a day. The table
+   * only holds ids, but it grows with every pushed message forever otherwise,
+   * and an anchor nobody replied to in 30 days will never be replied to. The
+   * timer is `unref`'d so it never holds the process open.
+   */
+  private startPushAnchorPurge(log: KernelLogger): void {
+    const purge = (): void => {
+      try {
+        const removed = pushedMessagesDb.purgeOlderThan(PUSHED_MESSAGE_RETENTION_DAYS);
+        if (removed > 0) {
+          log.info(
+            'discord/pushAnchors',
+            `purged ${removed} push anchor(s) older than ${PUSHED_MESSAGE_RETENTION_DAYS}d`,
+          );
+        }
+      } catch (err) {
+        void log.error('discord/pushAnchors', `purge failed: ${String(err)}`);
+      }
+    };
+    purge();
+    this.pushPurgeTimer = setInterval(purge, 24 * 60 * 60 * 1000);
+    this.pushPurgeTimer.unref?.();
+  }
+
   async stop(): Promise<void> {
+    if (this.pushPurgeTimer) {
+      clearInterval(this.pushPurgeTimer);
+      this.pushPurgeTimer = null;
+    }
     if (this.roomStall) {
       this.roomStall.clear();
       this.roomStall = null;
@@ -277,7 +315,7 @@ export class DiscordProvider implements BridgeProvider {
     };
   }
 
-  async send(target: ChannelTarget, msg: OutgoingMessage): Promise<void> {
+  async send(target: ChannelTarget, msg: OutgoingMessage): Promise<SendResult> {
     const channel = await this.fetchSendable(target.channelId);
 
     // Callout messages render as a colored embed; the human mention (when any)
@@ -298,7 +336,8 @@ export class DiscordProvider implements BridgeProvider {
           ? `<@${discordConfig.mentionUserId}>`
           : undefined;
       try {
-        await channel.send({ content, embeds: [embed] });
+        const sent = await channel.send({ content, embeds: [embed] });
+        return { messageId: sent.id };
       } catch (err) {
         const rl = toRateLimitError(err);
         if (rl) throw rl;
@@ -313,14 +352,14 @@ export class DiscordProvider implements BridgeProvider {
         );
         const fallback = content ? `${content} ${msg.text}` : msg.text;
         try {
-          await channel.send(fallback);
+          const sent = await channel.send(fallback);
+          return { messageId: sent.id };
         } catch (fallbackErr) {
           const fallbackRl = toRateLimitError(fallbackErr);
           if (fallbackRl) throw fallbackRl;
           throw fallbackErr;
         }
       }
-      return;
     }
 
     let text = msg.text;
@@ -328,11 +367,34 @@ export class DiscordProvider implements BridgeProvider {
       text = `<@${discordConfig.mentionUserId}> ${text}`;
     }
     try {
-      await channel.send(text);
+      const sent = await channel.send(text);
+      return { messageId: sent.id };
     } catch (err) {
       const rl = toRateLimitError(err);
       if (rl) throw rl;
       throw err;
+    }
+  }
+
+  /**
+   * Persist a pushed message as a reply anchor. Called by the push API after a
+   * successful `/api/send`; a thread later started on that message inherits the
+   * agent and session recorded here (`messageCreate` adopt-on-miss).
+   * Best-effort — a failed bookkeeping write must never fail the push itself.
+   */
+  recordPushedMessage(record: PushedMessage): void {
+    try {
+      pushedMessagesDb.record(
+        record.messageId,
+        record.channelId,
+        record.agentId,
+        record.sessionId ?? null,
+      );
+    } catch (err) {
+      void logger.error(
+        'discord/recordPushedMessage',
+        err instanceof Error ? err.message : String(err),
+      );
     }
   }
 

--- a/src/providers/discord/commands/agents.ts
+++ b/src/providers/discord/commands/agents.ts
@@ -8,6 +8,7 @@ import {
 import { maestro } from '../../../core/maestro';
 import { channelDb } from '../channelsDb';
 import { threadDb } from '../threadsDb';
+import { pushedMessagesDb } from '../pushedMessagesDb';
 import { cleanupAgentFiles } from '../../../core/attachments';
 import { clampFieldValue, clampTitle } from '../embed';
 import { discordConfig } from '../config';
@@ -350,8 +351,11 @@ async function handleDisconnect(interaction: ChatInputCommandInteraction): Promi
     );
   }
 
-  // Remove channel and its threads from DB
+  // Remove channel and its threads from DB. Push anchors for the channel go
+  // too: with the binding gone they can only ever adopt a thread into an agent
+  // this channel no longer belongs to.
   threadDb.removeByChannel(interaction.channelId);
+  pushedMessagesDb.removeByChannel(interaction.channelId);
   channelDb.remove(interaction.channelId);
 
   setTimeout(async () => {

--- a/src/providers/discord/messageCreate.ts
+++ b/src/providers/discord/messageCreate.ts
@@ -14,13 +14,15 @@ import { logger as defaultLogger } from '../../core/logger';
 import { splitMessage } from '../../core/splitMessage';
 import { channelDb } from './channelsDb';
 import { threadDb } from './threadsDb';
+import { pushedMessagesDb } from './pushedMessagesDb';
 import { discordAttachmentToIncoming, isVoiceAttachment, isVoiceMessage } from './voice';
 
 type Enqueue = (msg: IncomingMessage, options?: EnqueueOptions) => void;
 
 export type MessageCreateDeps = {
   channelDb: Pick<typeof channelDb, 'get'>;
-  threadDb: Pick<typeof threadDb, 'get' | 'register'>;
+  threadDb: Pick<typeof threadDb, 'get' | 'register' | 'adopt'>;
+  pushedMessagesDb: Pick<typeof pushedMessagesDb, 'get'>;
   getBotUserId: (message: Message) => string | undefined;
   enqueue: Enqueue;
   isVoiceMessage: typeof isVoiceMessage;
@@ -46,6 +48,70 @@ function toIncoming(message: Message, attachmentSource?: IncomingAttachment[]): 
     isThread: message.channel.isThread(),
     raw: message,
   };
+}
+
+/**
+ * Adopt-on-miss: bind a thread the bridge never created to the agent session
+ * that produced the message the thread hangs off.
+ *
+ * When an agent pushes autonomously (`POST /api/send`) and a human starts a
+ * thread on that message to answer it, the thread is unknown to
+ * `discord_agent_threads` and the turn used to be dropped on the floor. Discord
+ * gives such a thread the *same snowflake as its root message*, so the thread id
+ * is a direct key into the push-anchor table: a hit means this thread is a reply
+ * to that push, and it is registered on the spot with the pushed message's agent
+ * and session. The turn then flows through the normal thread path and lands in
+ * the originating session rather than a fresh one.
+ *
+ * Thread-only by design (v1): an *inline* reply stays in the parent channel, and
+ * routing it to the push's session would make the windup session and ordinary
+ * channel traffic share one queue key (`core/queue.ts` keys on channel id).
+ *
+ * The adopting thread binds to whoever replied first, matching the ownership
+ * rule for mention-created threads. Returns the registered row, or `undefined`
+ * when there is no anchor (the normal "unregistered thread" case).
+ */
+function adoptPushedThread(
+  deps: MessageCreateDeps,
+  log: KernelLogger,
+  message: Message,
+): ReturnType<MessageCreateDeps['threadDb']['get']> {
+  const threadId = message.channel.id;
+  const anchor = deps.pushedMessagesDb.get(threadId);
+  if (!anchor) return undefined;
+
+  // A thread's snowflake equals its root message's, so a hit already implies the
+  // right channel; assert it anyway rather than binding a thread to an agent
+  // channel it does not live under.
+  const parentId = (message.channel as { parentId?: string | null }).parentId;
+  if (parentId && parentId !== anchor.channel_id) {
+    log.warn(
+      'messageCreate/adopt',
+      `thread ${threadId} parent ${parentId} != anchor channel ${anchor.channel_id}, ignoring`,
+    );
+    return undefined;
+  }
+
+  try {
+    deps.threadDb.adopt(
+      threadId,
+      anchor.channel_id,
+      anchor.agent_id,
+      message.author.id,
+      anchor.session_id,
+    );
+  } catch (err) {
+    void log.error('messageCreate/adopt', `failed to adopt thread ${threadId}: ${String(err)}`);
+    return undefined;
+  }
+
+  log.info(
+    'messageCreate/adopt',
+    `adopted thread ${threadId} → agent ${anchor.agent_id} session ${anchor.session_id ?? 'new'}`,
+  );
+  // Re-read rather than synthesizing the row: `adopt` is INSERT OR IGNORE, so a
+  // concurrent first reply may have won and its binding is the one in force.
+  return deps.threadDb.get(threadId);
 }
 
 export function createMessageCreateHandler(deps: MessageCreateDeps) {
@@ -131,7 +197,8 @@ export function createMessageCreateHandler(deps: MessageCreateDeps) {
       return;
     }
 
-    const threadInfo = deps.threadDb.get(message.channel.id);
+    const threadInfo =
+      deps.threadDb.get(message.channel.id) ?? adoptPushedThread(deps, log, message);
     if (!threadInfo) return;
 
     const ownerUserId = threadInfo.owner_user_id?.trim();

--- a/src/providers/discord/messageCreate.ts
+++ b/src/providers/discord/messageCreate.ts
@@ -67,6 +67,22 @@ function toIncoming(message: Message, attachmentSource?: IncomingAttachment[]): 
  * routing it to the push's session would make the windup session and ordinary
  * channel traffic share one queue key (`core/queue.ts` keys on channel id).
  *
+ * Inheriting the push's *session* is gated on the anchor's `owner_user_id`,
+ * because continuing a session means reading and extending its context:
+ *
+ * - replier **is** the anchor's owner → inherit `session_id`, the full
+ *   "answer the push" path;
+ * - anchor has **no** owner (no `userId` on the push, no configured mention
+ *   user) → adopt into a *fresh* session, so the turn still reaches the right
+ *   agent but carries none of the pushed session's context;
+ * - replier is **someone else** → refuse. The thread stays unbound so its
+ *   rightful owner can still claim it, and the bystander keeps the pre-existing
+ *   route to the agent: @-mention it in the channel for a session of their own.
+ *
+ * Without that gate any member able to open a thread on an agent push could
+ * take over the referenced session, which is strictly more than the mention
+ * path (a fresh session) ever granted them.
+ *
  * The adopting thread binds to whoever replied first, matching the ownership
  * rule for mention-created threads. Returns the registered row, or `undefined`
  * when there is no anchor (the normal "unregistered thread" case).
@@ -92,13 +108,25 @@ function adoptPushedThread(
     return undefined;
   }
 
+  const anchorOwner = anchor.owner_user_id?.trim() || null;
+  if (anchorOwner && anchorOwner !== message.author.id) {
+    log.warn(
+      'messageCreate/adopt',
+      `thread ${threadId} reply from ${message.author.id} != anchor owner ${anchorOwner}, refusing session handover`,
+    );
+    return undefined;
+  }
+  // Only a vetted owner inherits the pushed session; an unowned anchor still
+  // routes to the agent, but in a session of its own.
+  const inheritedSession = anchorOwner ? anchor.session_id : null;
+
   try {
     deps.threadDb.adopt(
       threadId,
       anchor.channel_id,
       anchor.agent_id,
       message.author.id,
-      anchor.session_id,
+      inheritedSession,
     );
   } catch (err) {
     void log.error('messageCreate/adopt', `failed to adopt thread ${threadId}: ${String(err)}`);
@@ -107,7 +135,7 @@ function adoptPushedThread(
 
   log.info(
     'messageCreate/adopt',
-    `adopted thread ${threadId} → agent ${anchor.agent_id} session ${anchor.session_id ?? 'new'}`,
+    `adopted thread ${threadId} → agent ${anchor.agent_id} session ${inheritedSession ?? 'new'}`,
   );
   // Re-read rather than synthesizing the row: `adopt` is INSERT OR IGNORE, so a
   // concurrent first reply may have won and its binding is the one in force.

--- a/src/providers/discord/pushedMessagesDb.ts
+++ b/src/providers/discord/pushedMessagesDb.ts
@@ -1,0 +1,68 @@
+import { db } from '../../core/db';
+
+/**
+ * Registry of messages the bridge pushed into Discord on an agent's behalf
+ * (`POST /api/send`).
+ *
+ * Its one job is to make an agent push *answerable*: Discord assigns a thread
+ * created from a message the same snowflake as that message, so a thread id the
+ * bridge has never seen before can be looked up here to discover which agent
+ * (and which maestro session) posted the message the human just replied to.
+ *
+ * Only ids are stored — never message content. Rows expire via
+ * `purgeOlderThan`, since an anchor nobody has replied to in a month is dead
+ * weight.
+ */
+
+export interface DiscordPushedMessage {
+  message_id: string;
+  channel_id: string;
+  agent_id: string;
+  session_id: string | null;
+  created_at: number;
+}
+
+/** Default retention for push anchors. */
+export const PUSHED_MESSAGE_RETENTION_DAYS = 30;
+
+export const pushedMessagesDb = {
+  /**
+   * Record a pushed message. `INSERT OR REPLACE` because a message id is
+   * globally unique in Discord — a repeat is a re-record of the same message,
+   * and the newest agent/session binding is the correct one.
+   */
+  record(
+    messageId: string,
+    channelId: string,
+    agentId: string,
+    sessionId: string | null = null,
+  ): void {
+    db.prepare(
+      `INSERT OR REPLACE INTO discord_pushed_messages (message_id, channel_id, agent_id, session_id)
+       VALUES (?, ?, ?, ?)`,
+    ).run(messageId, channelId, agentId, sessionId);
+  },
+
+  get(messageId: string): DiscordPushedMessage | undefined {
+    return db
+      .prepare('SELECT * FROM discord_pushed_messages WHERE message_id = ?')
+      .get(messageId) as DiscordPushedMessage | undefined;
+  },
+
+  /**
+   * Drop anchors older than `days`. Returns the number of rows removed so the
+   * caller can log it. Safe to run on every startup.
+   */
+  purgeOlderThan(days: number = PUSHED_MESSAGE_RETENTION_DAYS): number {
+    const cutoff = Math.floor(Date.now() / 1000) - days * 24 * 60 * 60;
+    const result = db
+      .prepare('DELETE FROM discord_pushed_messages WHERE created_at < ?')
+      .run(cutoff);
+    return result.changes;
+  },
+
+  /** Remove every anchor for a channel — used when a channel is unbound. */
+  removeByChannel(channelId: string): void {
+    db.prepare('DELETE FROM discord_pushed_messages WHERE channel_id = ?').run(channelId);
+  },
+};

--- a/src/providers/discord/pushedMessagesDb.ts
+++ b/src/providers/discord/pushedMessagesDb.ts
@@ -9,6 +9,12 @@ import { db } from '../../core/db';
  * bridge has never seen before can be looked up here to discover which agent
  * (and which maestro session) posted the message the human just replied to.
  *
+ * An anchor also carries the Discord user allowed to *inherit* that session
+ * (`owner_user_id`). Without that gate any member who can open a thread on the
+ * push would take over the referenced session and keep writing with its
+ * context; adoption therefore only hands over `session_id` to that user, and
+ * anyone else's reply starts fresh (see `messageCreate.adoptPushedThread`).
+ *
  * Only ids are stored — never message content. Rows expire via
  * `purgeOlderThan`, since an anchor nobody has replied to in a month is dead
  * weight.
@@ -19,11 +25,30 @@ export interface DiscordPushedMessage {
   channel_id: string;
   agent_id: string;
   session_id: string | null;
+  /**
+   * Discord user allowed to continue `session_id` by replying in a thread on
+   * this message. Null means nobody was vetted, in which case such a reply gets
+   * a fresh session instead of this one.
+   */
+  owner_user_id: string | null;
   created_at: number;
 }
 
 /** Default retention for push anchors. */
 export const PUSHED_MESSAGE_RETENTION_DAYS = 30;
+
+/**
+ * Who may inherit a push's session: the user the caller vetted, else the
+ * configured mention user (the human this bot's pushes are addressed to), else
+ * nobody. Blank strings — `DISCORD_MENTION_USER_ID` is `''` when unset — must
+ * collapse to null so an empty id never reads as a real owner.
+ */
+export function resolveAnchorOwner(
+  recordOwnerUserId: string | null | undefined,
+  mentionUserId: string | null | undefined,
+): string | null {
+  return recordOwnerUserId?.trim() || mentionUserId?.trim() || null;
+}
 
 export const pushedMessagesDb = {
   /**
@@ -36,11 +61,12 @@ export const pushedMessagesDb = {
     channelId: string,
     agentId: string,
     sessionId: string | null = null,
+    ownerUserId: string | null = null,
   ): void {
     db.prepare(
-      `INSERT OR REPLACE INTO discord_pushed_messages (message_id, channel_id, agent_id, session_id)
-       VALUES (?, ?, ?, ?)`,
-    ).run(messageId, channelId, agentId, sessionId);
+      `INSERT OR REPLACE INTO discord_pushed_messages (message_id, channel_id, agent_id, session_id, owner_user_id)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(messageId, channelId, agentId, sessionId, ownerUserId);
   },
 
   get(messageId: string): DiscordPushedMessage | undefined {

--- a/src/providers/discord/threadsDb.ts
+++ b/src/providers/discord/threadsDb.ts
@@ -17,6 +17,26 @@ export const threadDb = {
     ).run(threadId, channelId, agentId, ownerUserId);
   },
 
+  /**
+   * Register a thread the bridge did *not* create, carrying a session inherited
+   * from elsewhere (a push anchor — see `pushedMessagesDb`). Distinct from
+   * `register` in two ways: it seeds `session_id`, and it is a no-op when the
+   * thread is already registered, so two near-simultaneous first replies cannot
+   * make the second one throw on the primary key.
+   */
+  adopt(
+    threadId: string,
+    channelId: string,
+    agentId: string,
+    ownerUserId: string | null,
+    sessionId: string | null,
+  ): void {
+    db.prepare(
+      `INSERT OR IGNORE INTO discord_agent_threads (thread_id, channel_id, agent_id, owner_user_id, session_id)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(threadId, channelId, agentId, ownerUserId, sessionId);
+  },
+
   get(threadId: string): DiscordAgentThread | undefined {
     return db
       .prepare('SELECT * FROM discord_agent_threads WHERE thread_id = ?')


### PR DESCRIPTION
Closes the inbound half of the autonomous-relay loop for Discord (Lane 2, v1). Refs #63.

## Problem

An agent-initiated push (`POST /api/send`) was one-way. The bridge posted the message and discarded its id, so nothing recorded *which agent / which session* produced it. When a human started a thread on that message to answer, `messageCreate.ts` found no row in `discord_agent_threads` and dropped the turn silently.

## What this does

- **`discord_pushed_messages`** (migration 12, `src/core/db/migrations.ts`) — `message_id` PK → `channel_id`, `agent_id`, `session_id`, `created_at`. Ids only, never message content.
- **`send()` may report a message id.** `BridgeProvider.send` now returns `Promise<SendResult | void>`; the Discord adapter returns `{ messageId }` from all three post paths (embed, plaintext fallback, plain text). Slack / Teams / Telegram are untouched — `void` stays valid. `sendWithRetry` is generic so the result survives the retry wrapper.
- **`/api/send` accepts `sessionId`** and records one anchor per posted part — a long push splits into several messages and the human may well answer the last one. The response gains `messageIds`. Recording is best-effort: a bookkeeping failure never turns a delivered message into a 500.
- **Adopt-on-miss** (`messageCreate.ts`): Discord gives a thread created from a message the *same snowflake as that message*, so an unregistered thread id is a direct key into the anchor table. A hit registers the thread with the pushed agent and session (`threadDb.adopt`, `INSERT OR IGNORE`), binds the owner to the first replier — matching mention-created threads — and the turn flows through the existing thread path into the right session.
- **Retention**: 30-day purge on startup and daily thereafter (unref'd timer); a channel's anchors are also dropped when its agent is disconnected via `/agents disconnect`.
- **CLI**: `maestro-relay send --session <id>`.

Follow-up posting needed no change — `queue.ts` posts to `channelId`, which already resolves to the thread.

## Design decision: threads only (v1)

An **inline** reply in the parent channel is deliberately *not* routed. The queue keys on `provider:channelId` (`src/core/queue.ts:75`), so routing an inline reply into the push's session would make windup traffic and ordinary channel traffic share one processing queue. Answering in a thread keeps them separate. Documented in `docs/api.md` and `docs/discord.md`.

## Tests

**571 passing**, build green. New coverage:

- `pushedMessagesDb.test.ts` — record/get round-trip, null session default, re-record overwrite, purge (aged vs. fresh vs. retention edge), `removeByChannel`.
- `messageCreate.test.ts` — adopts a thread opened on a push (inherits agent + session, binds first replier), adopts with a null session, refuses when the thread parent ≠ anchor channel, leaves an already-adopted binding untouched, still drops threads with no anchor, and does not enqueue when `adopt` throws (a failed adopt must not route the turn into a fresh session).
- `server.test.ts` — anchor per posted part with `sessionId`, null session when omitted, blank `sessionId` treated as absent, 400 on non-string `sessionId`, providers without `recordPushedMessage` still succeed, and a throwing recorder still returns 200.
- `discord-callout.test.ts` — `send()` returns the message id for plain text, for a callout embed, and for the plaintext fallback; rate limits still surface instead of an id.
- `db-migrations.test.ts` — table shape/PK/nullability + `created_at` index, idempotent rerun, created on a legacy database.
- `sendRetry.test.ts` — result passthrough, including from the attempt that finally succeeded.

Purely additive: no existing behavior changes, no schema rewrites.