### PR TITLE
ci: run CI on rc branch PRs and pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, rc]
   push:
-    branches: [main]
+    branches: [main, rc]
 
 jobs:
   lint-and-format:


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` only triggers on `main`:

```yaml
on:
  pull_request:
    branches: [main]
  push:
    branches: [main]
```

So **PRs targeting `rc` get no real CI run at all**. CodeRabbit is the
only automation that fires, and it skips non-default branches — which
means an `rc` PR can look "green" while nothing has actually run `tsc`
or the test suite.

This bit us on #67 (inbound thread-session binding, including the
`owner_user_id` gate that fixed the session-hijack hole): it merged into
`rc` with zero CI checks, and the type-check + 579-test run had to be
reproduced by hand locally before merging.

## Change

Add `rc` to both branch filters. One-line-per-trigger change, no job or
step edits — `rc` PRs and pushes now get the exact same `npx tsc
--noEmit` + `npm test` gate as `main`.

## Notes

- No effect on `main`: its triggers are unchanged.
- No new jobs, no new secrets, no runner-cost surprise beyond the `rc`
  PRs that should have been running all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)